### PR TITLE
Added ToBool case for string, and added ToBool test cases

### DIFF
--- a/cast_test.go
+++ b/cast_test.go
@@ -42,3 +42,23 @@ func TestMaps(t *testing.T) {
 	var taxonomies = map[interface{}]interface{}{"tag": "tags", "group": "groups"}
 	assert.Equal(t, ToStringMap(taxonomies), map[string]interface{}{"tag": "tags", "group": "groups"})
 }
+
+func TestToBool(t *testing.T) {
+	assert.Equal(t, ToBool(0), false)
+	assert.Equal(t, ToBool(nil), false)
+	assert.Equal(t, ToBool("false"), false)
+	assert.Equal(t, ToBool("FALSE"), false)
+	assert.Equal(t, ToBool("False"), false)
+	assert.Equal(t, ToBool("f"), false)
+	assert.Equal(t, ToBool("F"), false)
+	assert.Equal(t, ToBool(false), false)
+	assert.Equal(t, ToBool("foo"), false)
+	
+	assert.Equal(t, ToBool("true"), true)
+	assert.Equal(t, ToBool("TRUE"), true)
+	assert.Equal(t, ToBool("True"), true)
+	assert.Equal(t, ToBool("t"), true)
+	assert.Equal(t, ToBool("T"), true)
+	assert.Equal(t, ToBool(1), true)
+	assert.Equal(t, ToBool(true), true)
+}

--- a/caste.go
+++ b/caste.go
@@ -45,6 +45,8 @@ func ToBoolE(i interface{}) (bool, error) {
 			return true, nil
 		}
 		return false, nil
+	case string:
+		return strconv.ParseBool(i.(string))
 	default:
 		return false, fmt.Errorf("Unable to Cast %#v to bool", i)
 	}


### PR DESCRIPTION
I found that this missing case was preventing viper to correctly understand boolean flags, as they were passed to the Set, SetDefault, etc functions as theirs string values. This fix the issue.
