### PR TITLE
Removed forgotten fmt.Println("here")

### DIFF
--- a/caste.go
+++ b/caste.go
@@ -186,7 +186,6 @@ func ToSliceE(i interface{}) ([]interface{}, error) {
 
 	switch v := i.(type) {
 	case []interface{}:
-		fmt.Println("here")
 		for _, u := range v {
 			s = append(s, u)
 		}


### PR DESCRIPTION
This line pollutes the output, it had to be removed.
Great library by the way!
