### PR TITLE
Updated README, it was describing the wrong return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ the desired type. **If input is provided that will not convert to that type, the
 0 or nil value for that type will be returned**.
 
 Cast also provides identical methods To_____E. These return the same result as
-the To_____ methods, plus an additional bool which tells you if it successfully
+the To_____ methods, plus an additional error which tells you if it successfully
 converted. Using these methods you can tell the difference between when the
 input matched the zero value or when the conversion failed and the zero value
 was returned.


### PR DESCRIPTION
Changed where was saying that the functions return a boolean while they actually return an error
