### PR TITLE
ToStringSliceE: Support string values

### DIFF
--- a/caste.go
+++ b/caste.go
@@ -294,7 +294,7 @@ func ToStringSliceE(i interface{}) ([]string, error) {
 	case []string:
 		return v, nil
 	case string:
-		return strings.Split(v, " "), nil
+		return strings.Fields(v), nil
 	default:
 		return a, fmt.Errorf("Unable to Cast %#v to []string", i)
 	}

--- a/caste.go
+++ b/caste.go
@@ -11,6 +11,7 @@ import (
 	"html/template"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	jww "github.com/spf13/jwalterweatherman"
@@ -292,6 +293,8 @@ func ToStringSliceE(i interface{}) ([]string, error) {
 		return a, nil
 	case []string:
 		return v, nil
+	case string:
+		return strings.Split(v, " "), nil
 	default:
 		return a, fmt.Errorf("Unable to Cast %#v to []string", i)
 	}


### PR DESCRIPTION
This should fix viper's `GetStringSlice()` method as well, which was failing to work on any environmental variables or command line args.