### PR TITLE
Adding ToStringMapStringSlice Method

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -42,6 +42,11 @@ func ToStringMapString(i interface{}) map[string]string {
 	return v
 }
 
+func ToStringMapStringSlice(i interface{}) map[string][]string {
+	v, _ := ToStringMapStringSliceE(i)
+	return v
+}
+
 func ToStringMapBool(i interface{}) map[string]bool {
 	v, _ := ToStringMapBoolE(i)
 	return v

--- a/cast_test.go
+++ b/cast_test.go
@@ -73,8 +73,43 @@ func TestErrorToString(t *testing.T) {
 func TestMaps(t *testing.T) {
 	var taxonomies = map[interface{}]interface{}{"tag": "tags", "group": "groups"}
 	var stringMapBool = map[interface{}]interface{}{"v1": true, "v2": false}
+
+	// ToStringMapString inputs/outputs
+	var stringMapString = map[string]string{"key 1": "value 1", "key 2": "value 2", "key 3": "value 3"}
+	var stringMapInterface = map[string]interface{}{"key 1": "value 1", "key 2": "value 2", "key 3": "value 3"}
+	var interfaceMapString = map[interface{}]string{"key 1": "value 1", "key 2": "value 2", "key 3": "value 3"}
+	var interfaceMapInterface = map[interface{}]interface{}{"key 1": "value 1", "key 2": "value 2", "key 3": "value 3"}
+
+	// ToStringMapStringSlice inputs/outputs
+	var stringMapStringSlice = map[string][]string{"key 1": []string{"value 1", "value 2", "value 3"}, "key 2": []string{"value 1", "value 2", "value 3"}, "key 3": []string{"value 1", "value 2", "value 3"}}
+	var stringMapInterfaceSlice = map[string][]interface{}{"key 1": []interface{}{"value 1", "value 2", "value 3"}, "key 2": []interface{}{"value 1", "value 2", "value 3"}, "key 3": []interface{}{"value 1", "value 2", "value 3"}}
+	var stringMapStringSingleSliceFieldsResult = map[string][]string{"key 1": []string{"value", "1"}, "key 2": []string{"value", "2"}, "key 3": []string{"value", "3"}}
+	var interfaceMapStringSlice = map[interface{}][]string{"key 1": []string{"value 1", "value 2", "value 3"}, "key 2": []string{"value 1", "value 2", "value 3"}, "key 3": []string{"value 1", "value 2", "value 3"}}
+	var interfaceMapInterfaceSlice = map[interface{}][]interface{}{"key 1": []interface{}{"value 1", "value 2", "value 3"}, "key 2": []interface{}{"value 1", "value 2", "value 3"}, "key 3": []interface{}{"value 1", "value 2", "value 3"}}
+
+	var stringMapStringSliceMultiple = map[string][]string{"key 1": []string{"value 1", "value 2", "value 3"}, "key 2": []string{"value 1", "value 2", "value 3"}, "key 3": []string{"value 1", "value 2", "value 3"}}
+	var stringMapStringSliceSingle = map[string][]string{"key 1": []string{"value 1"}, "key 2": []string{"value 2"}, "key 3": []string{"value 3"}}
+
 	assert.Equal(t, ToStringMap(taxonomies), map[string]interface{}{"tag": "tags", "group": "groups"})
 	assert.Equal(t, ToStringMapBool(stringMapBool), map[string]bool{"v1": true, "v2": false})
+
+	// ToStringMapString tests
+	assert.Equal(t, ToStringMapString(stringMapString), stringMapString)
+	assert.Equal(t, ToStringMapString(stringMapInterface), stringMapString)
+	assert.Equal(t, ToStringMapString(interfaceMapString), stringMapString)
+	assert.Equal(t, ToStringMapString(interfaceMapInterface), stringMapString)
+
+	// ToStringMapStringSlice tests
+	assert.Equal(t, ToStringMapStringSlice(stringMapStringSlice), stringMapStringSlice)
+	assert.Equal(t, ToStringMapStringSlice(stringMapInterfaceSlice), stringMapStringSlice)
+	assert.Equal(t, ToStringMapStringSlice(stringMapStringSliceMultiple), stringMapStringSlice)
+	assert.Equal(t, ToStringMapStringSlice(stringMapStringSliceMultiple), stringMapStringSlice)
+	assert.Equal(t, ToStringMapStringSlice(stringMapString), stringMapStringSliceSingle)
+	assert.Equal(t, ToStringMapStringSlice(stringMapInterface), stringMapStringSliceSingle)
+	assert.Equal(t, ToStringMapStringSlice(interfaceMapStringSlice), stringMapStringSlice)
+	assert.Equal(t, ToStringMapStringSlice(interfaceMapInterfaceSlice), stringMapStringSlice)
+	assert.Equal(t, ToStringMapStringSlice(interfaceMapString), stringMapStringSingleSliceFieldsResult)
+	assert.Equal(t, ToStringMapStringSlice(interfaceMapInterface), stringMapStringSingleSliceFieldsResult)
 }
 
 func TestSlices(t *testing.T) {

--- a/caste.go
+++ b/caste.go
@@ -211,18 +211,23 @@ func ToStringMapStringE(i interface{}) (map[string]string, error) {
 	var m = map[string]string{}
 
 	switch v := i.(type) {
-	case map[interface{}]interface{}:
-		for k, val := range v {
-			m[ToString(k)] = ToString(val)
-		}
-		return m, nil
+	case map[string]string:
+		return v, nil
 	case map[string]interface{}:
 		for k, val := range v {
 			m[ToString(k)] = ToString(val)
 		}
 		return m, nil
-	case map[string]string:
-		return v, nil
+	case map[interface{}]string:
+		for k, val := range v {
+			m[ToString(k)] = ToString(val)
+		}
+		return m, nil
+	case map[interface{}]interface{}:
+		for k, val := range v {
+			m[ToString(k)] = ToString(val)
+		}
+		return m, nil
 	default:
 		return m, fmt.Errorf("Unable to Cast %#v to map[string]string", i)
 	}
@@ -235,7 +240,28 @@ func ToStringMapStringSliceE(i interface{}) (map[string][]string, error) {
 	var m = map[string][]string{}
 
 	switch v := i.(type) {
-	case map[interface{}]interface{}:
+	case map[string][]string:
+		return v, nil
+	case map[string][]interface{}:
+		for k, val := range v {
+			m[ToString(k)] = ToStringSlice(val)
+		}
+		return m, nil
+	case map[string]string:
+		for k, val := range v {
+			m[ToString(k)] = []string{val}
+		}
+	case map[string]interface{}:
+		for k, val := range v {
+			m[ToString(k)] = []string{ToString(val)}
+		}
+		return m, nil
+	case map[interface{}][]string:
+		for k, val := range v {
+			m[ToString(k)] = ToStringSlice(val)
+		}
+		return m, nil
+	case map[interface{}]string:
 		for k, val := range v {
 			m[ToString(k)] = ToStringSlice(val)
 		}
@@ -245,27 +271,20 @@ func ToStringMapStringSliceE(i interface{}) (map[string][]string, error) {
 			m[ToString(k)] = ToStringSlice(val)
 		}
 		return m, nil
-	case map[string][]interface{}:
+	case map[interface{}]interface{}:
 		for k, val := range v {
-			m[ToString(k)] = ToStringSlice(val)
+			key, err := ToStringE(k)
+			if err != nil {
+				return m, fmt.Errorf("Unable to Cast %#v to map[string][]string", i)
+			}
+			value, err := ToStringSliceE(val)
+			if err != nil {
+				return m, fmt.Errorf("Unable to Cast %#v to map[string][]string", i)
+			}
+			m[key] = value
 		}
-		return m, nil
-	case map[string]interface{}:
-		for k, val := range v {
-			m[ToString(k)] = []string{ToString(val)}
-		}
-		return m, nil
-	case map[string][]string:
-		return v, nil
-	case map[string]string:
-		for k, val := range v {
-			m[ToString(k)] = []string{val}
-		}
-	default:
-		fmt.Printf("unexpected type %T", v)
-		return m, fmt.Errorf("Unable to Cast %#v to map[string][]string", i)
 	}
-	return m, fmt.Errorf("Unable to Cast %#v to map[string][]string", i)
+	return m, nil
 }
 
 func ToStringMapBoolE(i interface{}) (map[string]bool, error) {
@@ -351,7 +370,11 @@ func ToStringSliceE(i interface{}) ([]string, error) {
 	case string:
 		return strings.Fields(v), nil
 	default:
-		return a, fmt.Errorf("Unable to Cast %#v to []string", i)
+		str, err := ToStringE(v)
+		if err != nil {
+			return a, fmt.Errorf("Unable to Cast %#v to []string", i)
+		}
+		return []string{str}, nil
 	}
 
 	return a, fmt.Errorf("Unable to Cast %#v to []string", i)

--- a/caste.go
+++ b/caste.go
@@ -229,6 +229,45 @@ func ToStringMapStringE(i interface{}) (map[string]string, error) {
 	return m, fmt.Errorf("Unable to Cast %#v to map[string]string", i)
 }
 
+func ToStringMapStringSliceE(i interface{}) (map[string][]string, error) {
+	jww.DEBUG.Println("ToStringMapStringSliceE called on type:", reflect.TypeOf(i))
+
+	var m = map[string][]string{}
+
+	switch v := i.(type) {
+	case map[interface{}]interface{}:
+		for k, val := range v {
+			m[ToString(k)] = ToStringSlice(val)
+		}
+		return m, nil
+	case map[interface{}][]interface{}:
+		for k, val := range v {
+			m[ToString(k)] = ToStringSlice(val)
+		}
+		return m, nil
+	case map[string][]interface{}:
+		for k, val := range v {
+			m[ToString(k)] = ToStringSlice(val)
+		}
+		return m, nil
+	case map[string]interface{}:
+		for k, val := range v {
+			m[ToString(k)] = []string{ToString(val)}
+		}
+		return m, nil
+	case map[string][]string:
+		return v, nil
+	case map[string]string:
+		for k, val := range v {
+			m[ToString(k)] = []string{val}
+		}
+	default:
+		fmt.Printf("unexpected type %T", v)
+		return m, fmt.Errorf("Unable to Cast %#v to map[string][]string", i)
+	}
+	return m, fmt.Errorf("Unable to Cast %#v to map[string][]string", i)
+}
+
 func ToStringMapBoolE(i interface{}) (map[string]bool, error) {
 	jww.DEBUG.Println("ToStringMapBoolE called on type:", reflect.TypeOf(i))
 

--- a/caste.go
+++ b/caste.go
@@ -6,7 +6,6 @@
 package cast
 
 import (
-	"errors"
 	"fmt"
 	"html/template"
 	"reflect"
@@ -17,6 +16,7 @@ import (
 	jww "github.com/spf13/jwalterweatherman"
 )
 
+// ToTimeE casts an empty interface to time.Time.
 func ToTimeE(i interface{}) (tim time.Time, err error) {
 	i = indirect(i)
 	jww.DEBUG.Println("ToTimeE called on type:", reflect.TypeOf(i))
@@ -35,6 +35,7 @@ func ToTimeE(i interface{}) (tim time.Time, err error) {
 	}
 }
 
+// ToDurationE casts an empty interface to time.Duration.
 func ToDurationE(i interface{}) (d time.Duration, err error) {
 	i = indirect(i)
 	jww.DEBUG.Println("ToDurationE called on type:", reflect.TypeOf(i))
@@ -51,6 +52,7 @@ func ToDurationE(i interface{}) (d time.Duration, err error) {
 	}
 }
 
+// ToBoolE casts an empty interface to a bool.
 func ToBoolE(i interface{}) (bool, error) {
 	i = indirect(i)
 	jww.DEBUG.Println("ToBoolE called on type:", reflect.TypeOf(i))
@@ -72,6 +74,7 @@ func ToBoolE(i interface{}) (bool, error) {
 	}
 }
 
+// ToFloat64E casts an empty interface to a float64.
 func ToFloat64E(i interface{}) (float64, error) {
 	i = indirect(i)
 	jww.DEBUG.Println("ToFloat64E called on type:", reflect.TypeOf(i))
@@ -95,14 +98,14 @@ func ToFloat64E(i interface{}) (float64, error) {
 		v, err := strconv.ParseFloat(s, 64)
 		if err == nil {
 			return float64(v), nil
-		} else {
-			return 0.0, fmt.Errorf("Unable to Cast %#v to float", i)
 		}
+		return 0.0, fmt.Errorf("Unable to Cast %#v to float", i)
 	default:
 		return 0.0, fmt.Errorf("Unable to Cast %#v to float", i)
 	}
 }
 
+// ToIntE casts an empty interface to an int.
 func ToIntE(i interface{}) (int, error) {
 	i = indirect(i)
 	jww.DEBUG.Println("ToIntE called on type:", reflect.TypeOf(i))
@@ -122,17 +125,15 @@ func ToIntE(i interface{}) (int, error) {
 		v, err := strconv.ParseInt(s, 0, 0)
 		if err == nil {
 			return int(v), nil
-		} else {
-			return 0, fmt.Errorf("Unable to Cast %#v to int", i)
 		}
+		return 0, fmt.Errorf("Unable to Cast %#v to int", i)
 	case float64:
 		return int(s), nil
 	case bool:
 		if bool(s) {
 			return 1, nil
-		} else {
-			return 0, nil
 		}
+		return 0, nil
 	case nil:
 		return 0, nil
 	default:
@@ -179,6 +180,7 @@ func indirectToStringerOrError(a interface{}) interface{} {
 	return v.Interface()
 }
 
+// ToStringE casts an empty interface to a string.
 func ToStringE(i interface{}) (string, error) {
 	i = indirectToStringerOrError(i)
 	jww.DEBUG.Println("ToStringE called on type:", reflect.TypeOf(i))
@@ -205,6 +207,7 @@ func ToStringE(i interface{}) (string, error) {
 	}
 }
 
+// ToStringMapStringE casts an empty interface to a map[string]string.
 func ToStringMapStringE(i interface{}) (map[string]string, error) {
 	jww.DEBUG.Println("ToStringMapStringE called on type:", reflect.TypeOf(i))
 
@@ -231,9 +234,9 @@ func ToStringMapStringE(i interface{}) (map[string]string, error) {
 	default:
 		return m, fmt.Errorf("Unable to Cast %#v to map[string]string", i)
 	}
-	return m, fmt.Errorf("Unable to Cast %#v to map[string]string", i)
 }
 
+// ToStringMapStringSliceE casts an empty interface to a map[string][]string.
 func ToStringMapStringSliceE(i interface{}) (map[string][]string, error) {
 	jww.DEBUG.Println("ToStringMapStringSliceE called on type:", reflect.TypeOf(i))
 
@@ -283,10 +286,13 @@ func ToStringMapStringSliceE(i interface{}) (map[string][]string, error) {
 			}
 			m[key] = value
 		}
+	default:
+		return m, fmt.Errorf("Unable to Cast %#v to map[string][]string", i)
 	}
 	return m, nil
 }
 
+// ToStringMapBoolE casts an empty interface to a map[string]bool.
 func ToStringMapBoolE(i interface{}) (map[string]bool, error) {
 	jww.DEBUG.Println("ToStringMapBoolE called on type:", reflect.TypeOf(i))
 
@@ -308,9 +314,9 @@ func ToStringMapBoolE(i interface{}) (map[string]bool, error) {
 	default:
 		return m, fmt.Errorf("Unable to Cast %#v to map[string]bool", i)
 	}
-	return m, fmt.Errorf("Unable to Cast %#v to map[string]bool", i)
 }
 
+// ToStringMapE casts an empty interface to a map[string]interface{}.
 func ToStringMapE(i interface{}) (map[string]interface{}, error) {
 	jww.DEBUG.Println("ToStringMapE called on type:", reflect.TypeOf(i))
 
@@ -327,10 +333,9 @@ func ToStringMapE(i interface{}) (map[string]interface{}, error) {
 	default:
 		return m, fmt.Errorf("Unable to Cast %#v to map[string]interface{}", i)
 	}
-
-	return m, fmt.Errorf("Unable to Cast %#v to map[string]interface{}", i)
 }
 
+// ToSliceE casts an empty interface to a []interface{}.
 func ToSliceE(i interface{}) ([]interface{}, error) {
 	jww.DEBUG.Println("ToSliceE called on type:", reflect.TypeOf(i))
 
@@ -350,10 +355,9 @@ func ToSliceE(i interface{}) ([]interface{}, error) {
 	default:
 		return s, fmt.Errorf("Unable to Cast %#v of type %v to []interface{}", i, reflect.TypeOf(i))
 	}
-
-	return s, fmt.Errorf("Unable to Cast %#v to []interface{}", i)
 }
 
+// ToStringSliceE casts an empty interface to a []string.
 func ToStringSliceE(i interface{}) ([]string, error) {
 	jww.DEBUG.Println("ToStringSliceE called on type:", reflect.TypeOf(i))
 
@@ -369,17 +373,18 @@ func ToStringSliceE(i interface{}) ([]string, error) {
 		return v, nil
 	case string:
 		return strings.Fields(v), nil
-	default:
+	case interface{}:
 		str, err := ToStringE(v)
 		if err != nil {
 			return a, fmt.Errorf("Unable to Cast %#v to []string", i)
 		}
 		return []string{str}, nil
+	default:
+		return a, fmt.Errorf("Unable to Cast %#v to []string", i)
 	}
-
-	return a, fmt.Errorf("Unable to Cast %#v to []string", i)
 }
 
+// ToIntSliceE casts an empty interface to a []int.
 func ToIntSliceE(i interface{}) ([]int, error) {
 	jww.DEBUG.Println("ToIntSliceE called on type:", reflect.TypeOf(i))
 
@@ -408,10 +413,9 @@ func ToIntSliceE(i interface{}) ([]int, error) {
 	default:
 		return []int{}, fmt.Errorf("Unable to Cast %#v to []int", i)
 	}
-
-	return []int{}, fmt.Errorf("Unable to Cast %#v to []int", i)
 }
 
+// StringToDate casts an empty interface to a time.Time.
 func StringToDate(s string) (time.Time, error) {
 	return parseDateWith(s, []string{
 		time.RFC3339,
@@ -436,5 +440,5 @@ func parseDateWith(s string, dates []string) (d time.Time, e error) {
 			return
 		}
 	}
-	return d, errors.New(fmt.Sprintf("Unable to parse date: %s", s))
+	return d, fmt.Errorf("Unable to parse date: %s", s)
 }


### PR DESCRIPTION
This should fix #15 and from my personal testing works.  I did notice there is no test method for a `ToStringMapString` so I didn't add a test for `ToStringMapStringSlice`.  Having a `ToStringMapString` test would have been nice to follow/modify for a `TestToStringMapStringSlice` function.