### PR TITLE
Add int64 and float64 type coercion in ToDuration

### DIFF
--- a/cast_test.go
+++ b/cast_test.go
@@ -6,9 +6,9 @@
 package cast
 
 import (
-	"testing"
-
 	"html/template"
+	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -150,4 +150,13 @@ func TestIndirectPointers(t *testing.T) {
 
 	assert.Equal(t, ToInt(y), 13)
 	assert.Equal(t, ToInt(z), 13)
+}
+
+func TestToDuration(t *testing.T) {
+	a := time.Second * 5
+	ai := int64(a)
+	b := time.Second * 5
+	bf := float64(b)
+	assert.Equal(t, ToDuration(ai), a)
+	assert.Equal(t, ToDuration(bf), b)
 }

--- a/caste.go
+++ b/caste.go
@@ -43,6 +43,12 @@ func ToDurationE(i interface{}) (d time.Duration, err error) {
 	switch s := i.(type) {
 	case time.Duration:
 		return s, nil
+	case int64:
+		d = time.Duration(s)
+		return
+	case float64:
+		d = time.Duration(s)
+		return
 	case string:
 		d, err = time.ParseDuration(s)
 		return


### PR DESCRIPTION
This bit us recently in Viper where we had some config values being put via an api request that was parsed as JSON. A time.Duration went out as a float64 and when it came back in as one it failed to parse and was silently set to 0. This resolves it (would be great to see Viper pull in this updated lib).

Thanks!