### PR TITLE
Add bool case to ToStringE

### DIFF
--- a/cast_test.go
+++ b/cast_test.go
@@ -40,6 +40,8 @@ func TestToString(t *testing.T) {
 	assert.Equal(t, ToString(template.URL("http://somehost.foo")), "http://somehost.foo")
 	assert.Equal(t, ToString(foo), "one more time")
 	assert.Equal(t, ToString(nil), "")
+	assert.Equal(t, ToString(true), "true")
+	assert.Equal(t, ToString(false), "false")
 }
 
 type foo struct {

--- a/caste.go
+++ b/caste.go
@@ -188,6 +188,8 @@ func ToStringE(i interface{}) (string, error) {
 	switch s := i.(type) {
 	case string:
 		return s, nil
+	case bool:
+		return strconv.FormatBool(s), nil
 	case float64:
 		return strconv.FormatFloat(i.(float64), 'f', -1, 64), nil
 	case int:


### PR DESCRIPTION
Casting an interface{} of type bool to string was missing. So added with this PR.

```
s,err := ToStringE(true)
fmt.Printf("%q Err: %s",s,err)
// Output: "true" Err:
```