### PR TITLE
Add ToTimeInDefaultLocation/E

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -17,6 +17,11 @@ func ToTime(i interface{}) time.Time {
 	return v
 }
 
+func ToTimeInDefaultLocation(i interface{}, location *time.Location) time.Time {
+	v, _ := ToTimeInDefaultLocationE(i, location)
+	return v
+}
+
 func ToDuration(i interface{}) time.Duration {
 	v, _ := ToDurationE(i)
 	return v

--- a/cast_test.go
+++ b/cast_test.go
@@ -6,6 +6,7 @@
 package cast
 
 import (
+	"fmt"
 	"html/template"
 	"testing"
 	"time"
@@ -176,4 +177,173 @@ func TestToDuration(t *testing.T) {
 	bf := float64(b)
 	assert.Equal(t, ToDuration(ai), a)
 	assert.Equal(t, ToDuration(bf), b)
+}
+
+func TestToTime(t *testing.T) {
+	est, err := time.LoadLocation("EST")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	irn, err := time.LoadLocation("Iran")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	swd, err := time.LoadLocation("Europe/Stockholm")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// time.Parse*() fns handle the target & local timezones being the same
+	// differently, so make sure we use one of the timezones as local by
+	// temporarily change it.
+	if !locationEqual(time.Local, swd) {
+		var originalLocation *time.Location
+		originalLocation, time.Local = time.Local, swd
+		defer func() {
+			time.Local = originalLocation
+		}()
+	}
+
+	// Test same local time in different timezones
+	utc2016 := time.Date(2016, time.January, 1, 0, 0, 0, 0, time.UTC)
+	est2016 := time.Date(2016, time.January, 1, 0, 0, 0, 0, est)
+	irn2016 := time.Date(2016, time.January, 1, 0, 0, 0, 0, irn)
+	swd2016 := time.Date(2016, time.January, 1, 0, 0, 0, 0, swd)
+
+	for _, format := range timeFormats {
+		t.Logf("Checking time format '%s', has timezone: %v", format.format, format.hasTimezone)
+
+		est2016str := est2016.Format(format.format)
+		if !assert.NotEmpty(t, est2016str) {
+			continue
+		}
+
+		swd2016str := swd2016.Format(format.format)
+		if !assert.NotEmpty(t, swd2016str) {
+			continue
+		}
+
+		// Test conversion without a default location
+		converted, err := ToTimeE(est2016str)
+		if assert.NoError(t, err) {
+			if format.hasTimezone {
+				// Converting inputs with a timezone should preserve it
+				assertTimeEqual(t, est2016, converted)
+				assertLocationEqual(t, est, converted.Location())
+			} else {
+				// Converting inputs without a timezone should be interpreted
+				// as a local time in UTC.
+				assertTimeEqual(t, utc2016, converted)
+				assertLocationEqual(t, time.UTC, converted.Location())
+			}
+		}
+
+		// Test conversion of a time in the local timezone without a default
+		// location
+		converted, err = ToTimeE(swd2016str)
+		if assert.NoError(t, err) {
+			if format.hasTimezone {
+				// Converting inputs with a timezone should preserve it
+				assertTimeEqual(t, swd2016, converted)
+				assertLocationEqual(t, swd, converted.Location())
+			} else {
+				// Converting inputs without a timezone should be interpreted
+				// as a local time in UTC.
+				assertTimeEqual(t, utc2016, converted)
+				assertLocationEqual(t, time.UTC, converted.Location())
+			}
+		}
+
+		// Conversion with a nil default location sould have same behavior
+		converted, err = ToTimeInDefaultLocationE(est2016str, nil)
+		if assert.NoError(t, err) {
+			if format.hasTimezone {
+				// Converting inputs with a timezone should preserve it
+				assertTimeEqual(t, est2016, converted)
+				assertLocationEqual(t, est, converted.Location())
+			} else {
+				// Converting inputs without a timezone should be interpreted
+				// as a local time in the local timezone.
+				assertTimeEqual(t, swd2016, converted)
+				assertLocationEqual(t, swd, converted.Location())
+			}
+		}
+
+		// Test conversion with a default location that isn't UTC
+		converted, err = ToTimeInDefaultLocationE(est2016str, irn)
+		if assert.NoError(t, err) {
+			if format.hasTimezone {
+				// Converting inputs with a timezone should preserve it
+				assertTimeEqual(t, est2016, converted)
+				assertLocationEqual(t, est, converted.Location())
+			} else {
+				// Converting inputs without a timezone should be interpreted
+				// as a local time in the given location.
+				assertTimeEqual(t, irn2016, converted)
+				assertLocationEqual(t, irn, converted.Location())
+			}
+		}
+
+		// Test conversion of a time in the local timezone with a default
+		// location that isn't UTC
+		converted, err = ToTimeInDefaultLocationE(swd2016str, irn)
+		if assert.NoError(t, err) {
+			if format.hasTimezone {
+				// Converting inputs with a timezone should preserve it
+				assertTimeEqual(t, swd2016, converted)
+				assertLocationEqual(t, swd, converted.Location())
+			} else {
+				// Converting inputs without a timezone should be interpreted
+				// as a local time in the given location.
+				assertTimeEqual(t, irn2016, converted)
+				assertLocationEqual(t, irn, converted.Location())
+			}
+		}
+	}
+}
+
+func assertTimeEqual(t *testing.T, expected, actual time.Time, msgAndArgs ...interface{}) bool {
+	if !expected.Equal(actual) {
+		return assert.Fail(t, fmt.Sprintf("Expected time '%s', got '%s'", expected, actual), msgAndArgs...)
+	}
+	return true
+}
+
+func assertLocationEqual(t *testing.T, expected, actual *time.Location, msgAndArgs ...interface{}) bool {
+	if !locationEqual(expected, actual) {
+		return assert.Fail(t, fmt.Sprintf("Expected location '%s', got '%s'", expected, actual), msgAndArgs...)
+	}
+	return true
+}
+
+func locationEqual(a, b *time.Location) bool {
+	// A note about comparring time.Locations:
+	//   - can't only compare pointers
+	//   - can't compare loc.String() because locations with the same
+	//     name can have different offsets
+	//   - can't use reflect.DeepEqual because time.Location has internal
+	//     caches
+
+	if a == b {
+		return true
+	} else if a == nil || b == nil {
+		return false
+	}
+
+	// Check if they're equal by parsing times with a format that doesn't
+	// include a timezone, which will interpret it as being a local time in
+	// the given zone, and comparing the resulting local times.
+	tA, err := time.ParseInLocation("2006-01-02", "2016-01-01", a)
+	if err != nil {
+		return false
+	}
+
+	tB, err := time.ParseInLocation("2006-01-02", "2016-01-01", b)
+	if err != nil {
+		return false
+	}
+
+	return tA.Equal(tB)
 }


### PR DESCRIPTION
Go's time parsing uses UTC when the format doesn't have a timezone, and has even weirder behavior when it has a zone name but no numeric offset. A caller to `cast.ToTime` cannot know if the returned time was explicitly in UTC or was set by default, so they cannot fix it. These new functions allow a user to supply a different timezone to default to, with nil using the local zone.

This addresses spf13/hugo#1882 by allowing that code to use `cast.ToTimeInDefaultLocation(raw, nil)`.

A note on the implementation: It's not possible to use `time.ParseInLocation` because parsing with a format that has a named zone but no numeric offset (such as `time.RC1123Z`) returns a time with a 0 offset in that name **iff** that's not the current local timezone (!!). You can verify this by changing like 521 to use `time.ParseInLocation(format.format, s, defaultLocation)` and commenting out the manual override in the body of the `if` clause – tests will fail.

I think the root cause is that the `time` pkg has two parsing functions: `time.Parse` and `time.ParseInLocation`, both of which use a private workhorse fn `time.parse`. That private fn takes two zones: a default and what's considered "local". I'm not sure, but I think in order to get the effect we want, we'd need to call that fn with our default and the current local zone. However, `time.Parse` uses default of UTC, whereas `time.ParseInLocation` uses the given zone for both default & local.
