### PR TITLE
fix bug identifying StringMapStringSlice

### DIFF
--- a/cast_test.go
+++ b/cast_test.go
@@ -107,6 +107,8 @@ func TestMaps(t *testing.T) {
 
 	var stringMapStringSliceMultiple = map[string][]string{"key 1": []string{"value 1", "value 2", "value 3"}, "key 2": []string{"value 1", "value 2", "value 3"}, "key 3": []string{"value 1", "value 2", "value 3"}}
 	var stringMapStringSliceSingle = map[string][]string{"key 1": []string{"value 1"}, "key 2": []string{"value 2"}, "key 3": []string{"value 3"}}
+	var stringMapStringInterfaceString = map[string]interface{}{"key 1": []string{"value 1", "value 2", "value 3"}, "key 2": []string{"value 1", "value 2", "value 3"}, "key 3": []string{"value 1", "value 2", "value 3"}}
+	var stringMapStringInterface = map[string]interface{}{"key 1": []interface{}{"value 1", "value 2", "value 3"}, "key 2": []interface{}{"value 1", "value 2", "value 3"}, "key 3": []interface{}{"value 1", "value 2", "value 3"}}
 
 	assert.Equal(t, ToStringMap(taxonomies), map[string]interface{}{"tag": "tags", "group": "groups"})
 	assert.Equal(t, ToStringMapBool(stringMapBool), map[string]bool{"v1": true, "v2": false})
@@ -121,7 +123,8 @@ func TestMaps(t *testing.T) {
 	assert.Equal(t, ToStringMapStringSlice(stringMapStringSlice), stringMapStringSlice)
 	assert.Equal(t, ToStringMapStringSlice(stringMapInterfaceSlice), stringMapStringSlice)
 	assert.Equal(t, ToStringMapStringSlice(stringMapStringSliceMultiple), stringMapStringSlice)
-	assert.Equal(t, ToStringMapStringSlice(stringMapStringSliceMultiple), stringMapStringSlice)
+	assert.Equal(t, ToStringMapStringSlice(stringMapStringInterfaceString), stringMapStringSlice)
+	assert.Equal(t, ToStringMapStringSlice(stringMapStringInterface), stringMapStringSlice)
 	assert.Equal(t, ToStringMapStringSlice(stringMapString), stringMapStringSliceSingle)
 	assert.Equal(t, ToStringMapStringSlice(stringMapInterface), stringMapStringSliceSingle)
 	assert.Equal(t, ToStringMapStringSlice(interfaceMapStringSlice), stringMapStringSlice)

--- a/caste.go
+++ b/caste.go
@@ -310,7 +310,11 @@ func ToStringMapStringSliceE(i interface{}) (map[string][]string, error) {
 		}
 	case map[string]interface{}:
 		for k, val := range v {
-			m[ToString(k)] = []string{ToString(val)}
+			if reflect.TypeOf(val).Kind() == reflect.Slice {
+				m[ToString(k)] = ToStringSlice(val)
+			} else {
+				m[ToString(k)] = []string{ToString(val)}
+			}
 		}
 		return m, nil
 	case map[interface{}][]string:


### PR DESCRIPTION
This fixes an issue identifying `map[string][]string` when the input is `map[string]interface{}`.