### PR TITLE
Fixed `ToDurationE()`: More cases were added

### DIFF
--- a/cast_test.go
+++ b/cast_test.go
@@ -170,10 +170,29 @@ func TestIndirectPointers(t *testing.T) {
 }
 
 func TestToDuration(t *testing.T) {
-	a := time.Second * 5
-	ai := int64(a)
-	b := time.Second * 5
-	bf := float64(b)
-	assert.Equal(t, ToDuration(ai), a)
-	assert.Equal(t, ToDuration(bf), b)
+	var td time.Duration = 5
+	tests := []struct {
+		input    interface{}
+		expected time.Duration
+	}{
+		{time.Duration(5), td},
+		{int64(5), td},
+		{int32(5), td},
+		{int16(5), td},
+		{int8(5), td},
+		{int(5), td},
+		{float64(5), td},
+		{float32(5), td},
+		{string("5"), td},
+		{string("5ns"), td},
+		{string("5us"), time.Microsecond * td},
+		{string("5µs"), time.Microsecond * td},
+		{string("5ms"), time.Millisecond * td},
+		{string("5s"), time.Second * td},
+		{string("5m"), time.Minute * td},
+		{string("5h"), time.Hour * td},
+	}
+	for _, v := range tests {
+		assert.Equal(t, v.expected, ToDuration(v.input))
+	}
 }

--- a/caste.go
+++ b/caste.go
@@ -43,14 +43,18 @@ func ToDurationE(i interface{}) (d time.Duration, err error) {
 	switch s := i.(type) {
 	case time.Duration:
 		return s, nil
-	case int64:
-		d = time.Duration(s)
+	case int64, int32, int16, int8, int:
+		d = time.Duration(ToInt64(s))
 		return
-	case float64:
-		d = time.Duration(s)
+	case float32, float64:
+		d = time.Duration(ToFloat64(s))
 		return
 	case string:
-		d, err = time.ParseDuration(s)
+		if strings.ContainsAny(s, "nsuµmh") {
+			d, err = time.ParseDuration(s)
+		} else {
+			d, err = time.ParseDuration(s + "ns")
+		}
 		return
 	default:
 		err = fmt.Errorf("Unable to Cast %#v to Duration\n", i)


### PR DESCRIPTION
It used to return zero valeus in some cases. The details are described in [this issue](https://github.com/spf13/viper/issues/203). More cases were also added in the unit test `TestToDuration()`