### PR TITLE
Fix multiple interface{} values to ToStringMapStringSliceE

### DIFF
--- a/cast_test.go
+++ b/cast_test.go
@@ -106,6 +106,7 @@ func TestMaps(t *testing.T) {
 	var interfaceMapInterfaceSlice = map[interface{}][]interface{}{"key 1": []interface{}{"value 1", "value 2", "value 3"}, "key 2": []interface{}{"value 1", "value 2", "value 3"}, "key 3": []interface{}{"value 1", "value 2", "value 3"}}
 
 	var stringMapStringSliceMultiple = map[string][]string{"key 1": []string{"value 1", "value 2", "value 3"}, "key 2": []string{"value 1", "value 2", "value 3"}, "key 3": []string{"value 1", "value 2", "value 3"}}
+	var stringMapInterfaceMultiple = map[string]interface{}{"key 1": []string{"value 1", "value 2", "value 3"}, "key 2": []string{"value 1", "value 2", "value 3"}, "key 3": []string{"value 1", "value 2", "value 3"}}
 	var stringMapStringSliceSingle = map[string][]string{"key 1": []string{"value 1"}, "key 2": []string{"value 2"}, "key 3": []string{"value 3"}}
 
 	assert.Equal(t, ToStringMap(taxonomies), map[string]interface{}{"tag": "tags", "group": "groups"})
@@ -122,6 +123,7 @@ func TestMaps(t *testing.T) {
 	assert.Equal(t, ToStringMapStringSlice(stringMapInterfaceSlice), stringMapStringSlice)
 	assert.Equal(t, ToStringMapStringSlice(stringMapStringSliceMultiple), stringMapStringSlice)
 	assert.Equal(t, ToStringMapStringSlice(stringMapStringSliceMultiple), stringMapStringSlice)
+	assert.Equal(t, ToStringMapStringSlice(stringMapInterfaceMultiple), stringMapStringSlice)
 	assert.Equal(t, ToStringMapStringSlice(stringMapString), stringMapStringSliceSingle)
 	assert.Equal(t, ToStringMapStringSlice(stringMapInterface), stringMapStringSliceSingle)
 	assert.Equal(t, ToStringMapStringSlice(interfaceMapStringSlice), stringMapStringSlice)

--- a/caste.go
+++ b/caste.go
@@ -310,7 +310,12 @@ func ToStringMapStringSliceE(i interface{}) (map[string][]string, error) {
 		}
 	case map[string]interface{}:
 		for k, val := range v {
-			m[ToString(k)] = []string{ToString(val)}
+			switch val.(type) {
+			case []string:
+				m[ToString(k)] = ToStringSlice(val)
+			default:
+				m[ToString(k)] = []string{ToString(val)}
+			}
 		}
 		return m, nil
 	case map[interface{}][]string:


### PR DESCRIPTION
This fixes passing `map[string]interface{}` with the map containing multiple strings. Previously the result is a slice with an empty string in it.

I discovered when using https://github.com/spf13/viper with the following:

```json
{
  "key": [
    "val1",
    "val2"
  ]
}
```

Viper resolved this to `map[string]interface{}` and the `val` key became `[]string{""}`