### PR TITLE
Fix regression in StringToDate

### DIFF
--- a/cast_test.go
+++ b/cast_test.go
@@ -206,6 +206,7 @@ func TestToTimeE(t *testing.T) {
 		{"Nov 10 23:00:00.000", time.Date(0, 11, 10, 23, 0, 0, 0, time.UTC)},                // StampMilli
 		{"Nov 10 23:00:00.000000", time.Date(0, 11, 10, 23, 0, 0, 0, time.UTC)},             // StampMicro
 		{"Nov 10 23:00:00.000000000", time.Date(0, 11, 10, 23, 0, 0, 0, time.UTC)},          // StampNano
+		{"2016-03-06 15:28:01-00:00", time.Date(2016, 3, 6, 15, 28, 1, 0, time.UTC)},        // RFC3339 without T
 		{"2016-03-06 15:28:01", time.Date(2016, 3, 6, 15, 28, 1, 0, time.UTC)},
 		{"2016-03-06 15:28:01 -0000", time.Date(2016, 3, 6, 15, 28, 1, 0, time.UTC)},
 		{"2016-03-06 15:28:01 -00:00", time.Date(2016, 3, 6, 15, 28, 1, 0, time.UTC)},

--- a/caste.go
+++ b/caste.go
@@ -519,6 +519,7 @@ func StringToDate(s string) (time.Time, error) {
 		"02 Jan 2006",
 		"2006-01-02 15:04:05 -07:00",
 		"2006-01-02 15:04:05 -0700",
+		"2006-01-02 15:04:05Z07:00", // RFC3339 without T
 		"2006-01-02 15:04:05",
 		time.Kitchen,
 		time.Stamp,


### PR DESCRIPTION
In commit d1139ba, I removed a date format for "RFC3339 without T" that
I misidentified as a reduntant format.  This commit adds it back with a
test.