### PR TITLE
Add ToSliceStringMapStringE function

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -151,3 +151,9 @@ func ToIntSlice(i interface{}) []int {
 	v, _ := ToIntSliceE(i)
 	return v
 }
+
+// ToSliceStringMapString casts an interface to a []map[string]string type.
+func ToSliceStringMapString(i interface{}) []map[string]string {
+	v, _ := ToSliceStringMapStringE(i)
+	return v
+}

--- a/cast_test.go
+++ b/cast_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type Key struct {
+	k string
+}
+
 func TestToUintE(t *testing.T) {
 	tests := []struct {
 		input  interface{}
@@ -593,9 +597,6 @@ func TestToFloat32E(t *testing.T) {
 }
 
 func TestToStringE(t *testing.T) {
-	type Key struct {
-		k string
-	}
 	key := &Key{"foo"}
 
 	tests := []struct {
@@ -971,6 +972,57 @@ func TestToStringSliceE(t *testing.T) {
 
 		// Non-E test
 		v = ToStringSlice(test.input)
+		assert.Equal(t, test.expect, v, errmsg)
+	}
+}
+
+func TestToSliceStringMapString(t *testing.T) {
+	var sliceStringMapString = []map[string]string{
+		{"key 1": "value 1", "key 2": "value 2"},
+		{"key 3": "value 3", "key 4": "value 4"},
+	}
+	var sliceInterfaceMapString = []map[interface{}]string{
+		{"key 1": "value 1", "key 2": "value 2"},
+		{"key 3": "value 3", "key 4": "value 4"},
+	}
+	var sliceInterfaceMapInterface = []map[interface{}]string{
+		{"key 1": "value 1", "key 2": "value 2"},
+		{"key 3": "value 3", "key 4": "value 4"},
+	}
+	var sliceStringMapInterface = []map[interface{}]string{
+		{"key 1": "value 1", "key 2": "value 2"},
+		{"key 3": "value 3", "key 4": "value 4"},
+	}
+
+	tests := []struct {
+		input  interface{}
+		expect []map[string]string
+		iserr  bool
+	}{
+		{sliceStringMapString, sliceStringMapString, false},
+		{sliceStringMapInterface, sliceStringMapString, false},
+		{sliceInterfaceMapString, sliceStringMapString, false},
+		{sliceInterfaceMapInterface, sliceStringMapString, false},
+		// errors
+		{nil, nil, true},
+		{testing.T{}, nil, true},
+		{[]Key{{"foo"}, {"bar"}}, nil, true},
+	}
+
+	for i, test := range tests {
+		errmsg := fmt.Sprintf("i = %d", i) // assert helper message
+
+		v, err := ToSliceStringMapStringE(test.input)
+		if test.iserr {
+			assert.Error(t, err, errmsg)
+			continue
+		}
+
+		assert.NoError(t, err, errmsg)
+		assert.Equal(t, test.expect, v, errmsg)
+
+		// Non-E test
+		v = ToSliceStringMapString(test.input)
 		assert.Equal(t, test.expect, v, errmsg)
 	}
 }

--- a/caste.go
+++ b/caste.go
@@ -1077,6 +1077,35 @@ func ToIntSliceE(i interface{}) ([]int, error) {
 	}
 }
 
+// ToSliceStringMapString casts an interface to a []map[string]string type.
+func ToSliceStringMapStringE(i interface{}) ([]map[string]string, error) {
+	if i == nil {
+		return []map[string]string{}, fmt.Errorf("unable to cast %#v of type %T to []map[string]string", i, i)
+	}
+
+	switch v := i.(type) {
+	case []map[string]string:
+		return v, nil
+	}
+
+	kind := reflect.TypeOf(i).Kind()
+	switch kind {
+	case reflect.Slice, reflect.Array:
+		s := reflect.ValueOf(i)
+		a := make([]map[string]string, s.Len())
+		for j := 0; j < s.Len(); j++ {
+			val, err := ToStringMapStringE(s.Index(j).Interface())
+			if err != nil {
+				return []map[string]string{}, fmt.Errorf("unable to cast %#v of type %T to []map[string]string", i, i)
+			}
+			a[j] = val
+		}
+		return a, nil
+	default:
+		return []map[string]string{}, fmt.Errorf("unable to cast %#v of type %T to []map[string]string", i, i)
+	}
+}
+
 // StringToDate attempts to parse a string into a time.Time type using a
 // predefined list of formats.  If no suitable format is found, an error is
 // returned.


### PR DESCRIPTION
Submitting this PR for consideration.  Adding other ToSlice*Type*Map*Type* functions would be pretty straight-forward if we want to go this route.

Fixes #36 
