### PR TITLE
Add ToStringMapStruct()

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -128,6 +128,12 @@ func ToStringMap(i interface{}) map[string]interface{} {
 	return v
 }
 
+// ToStringMapStruct casts an interface to a map[string]struct{} type.
+func ToStringMapStruct(i interface{}) map[string]struct{} {
+	v, _ := ToStringMapStructE(i)
+	return v
+}
+
 // ToSlice casts an interface to a []interface{} type.
 func ToSlice(i interface{}) []interface{} {
 	v, _ := ToSliceE(i)

--- a/cast_test.go
+++ b/cast_test.go
@@ -774,6 +774,38 @@ func TestToStringMapE(t *testing.T) {
 	}
 }
 
+func TestToStringMapStructE(t *testing.T) {
+	tests := []struct {
+		input  interface{}
+		expect map[string]struct{}
+		iserr  bool
+	}{
+		{map[string]interface{}{"v1": true, "v2": false}, map[string]struct{}{"v1": struct{}{}, "v2": struct{}{}}, false},
+		{[]string{"v1", "v2"}, map[string]struct{}{"v1": struct{}{}, "v2": struct{}{}}, false},
+		{[]interface{}{"v1", "v2"}, map[string]struct{}{"v1": struct{}{}, "v2": struct{}{}}, false},
+		{map[string]struct{}{"v1": struct{}{}, "v2": struct{}{}}, map[string]struct{}{"v1": struct{}{}, "v2": struct{}{}}, false},
+		// errors
+		{nil, nil, true},
+		{testing.T{}, nil, true},
+	}
+	for i, test := range tests {
+		errmsg := fmt.Sprintf("i = %d", i) // assert helper message
+
+		v, err := ToStringMapStructE(test.input)
+		if test.iserr {
+			assert.Error(t, err, errmsg)
+			continue
+		}
+
+		assert.NoError(t, err, errmsg)
+		assert.Equal(t, test.expect, v, errmsg)
+
+		// Non-E test
+		v = ToStringMapStruct(test.input)
+		assert.Equal(t, test.expect, v, errmsg)
+	}
+}
+
 func TestToStringMapBoolE(t *testing.T) {
 	tests := []struct {
 		input  interface{}

--- a/caste.go
+++ b/caste.go
@@ -977,6 +977,36 @@ func ToStringMapE(i interface{}) (map[string]interface{}, error) {
 	}
 }
 
+// ToStringMapStructE casts an interface to a map[string]struct{} type.
+func ToStringMapStructE(i interface{}) (map[string]struct{}, error) {
+	var m = map[string]struct{}{}
+
+	fmt.Println("type: ", reflect.TypeOf(i))
+	switch v := i.(type) {
+	case map[string]interface{}:
+		for k := range v {
+			m[k] = struct{}{}
+		}
+		return m, nil
+	case []string:
+		fmt.Println("[]string")
+		for _, s := range v {
+			m[s] = struct{}{}
+		}
+		return m, nil
+	case []interface{}:
+		for _, k := range v {
+			m[ToString(k)] = struct{}{}
+		}
+		return m, nil
+	case map[string]struct{}:
+		return v, nil
+	default:
+		fmt.Println("cast err")
+		return m, fmt.Errorf("unable to cast %#v of type %T to map[string]interface{}", i, i)
+	}
+}
+
 // ToSliceE casts an interface to a []interface{} type.
 func ToSliceE(i interface{}) ([]interface{}, error) {
 	var s []interface{}


### PR DESCRIPTION
Add the possibility to cast a slice into a hashset (`map[string]struct{}`).

The `struct{}` element worth 0 byte, and it's really useful for checking if a key is present. [here an article about the empty struct](https://dave.cheney.net/2014/03/25/the-empty-struct).

This pull request is link with _github.com/spf13/viper_ to add this feature for parsing array.