### PR TITLE
StringToDate: +more RFC3339 forms without TZ colon

### DIFF
--- a/caste.go
+++ b/caste.go
@@ -1137,9 +1137,11 @@ func StringToDate(s string) (time.Time, error) {
 		"2006-01-02 15:04:05.999999999 -0700 MST", // Time.String()
 		"2006-01-02",
 		"02 Jan 2006",
+		"2006-01-02T15:04:05-0700", // RFC3339 without timezone hh:mm colon
 		"2006-01-02 15:04:05 -07:00",
 		"2006-01-02 15:04:05 -0700",
 		"2006-01-02 15:04:05Z07:00", // RFC3339 without T
+		"2006-01-02 15:04:05Z0700", // RFC3339 without T or timezone hh:mm colon
 		"2006-01-02 15:04:05",
 		time.Kitchen,
 		time.Stamp,


### PR DESCRIPTION
Adds a form to handle the common format `strftime("%FT%T%z")`, which
omits the (optional) colon from the timezone. Also adds a matching
T-omitted form.