### PR TITLE
fixes expected cast.ToInt behavior with prefixed "0" in string

### DIFF
--- a/caste.go
+++ b/caste.go
@@ -211,7 +211,7 @@ func ToInt64E(i interface{}) (int64, error) {
 	case float32:
 		return int64(s), nil
 	case string:
-		v, err := strconv.ParseInt(s, 0, 0)
+		v, err := strconv.ParseInt(s, 10, 0)
 		if err == nil {
 			return v, nil
 		}
@@ -258,7 +258,7 @@ func ToInt32E(i interface{}) (int32, error) {
 	case float32:
 		return int32(s), nil
 	case string:
-		v, err := strconv.ParseInt(s, 0, 0)
+		v, err := strconv.ParseInt(s, 10, 0)
 		if err == nil {
 			return int32(v), nil
 		}
@@ -305,7 +305,7 @@ func ToInt16E(i interface{}) (int16, error) {
 	case float32:
 		return int16(s), nil
 	case string:
-		v, err := strconv.ParseInt(s, 0, 0)
+		v, err := strconv.ParseInt(s, 10, 0)
 		if err == nil {
 			return int16(v), nil
 		}
@@ -352,7 +352,7 @@ func ToInt8E(i interface{}) (int8, error) {
 	case float32:
 		return int8(s), nil
 	case string:
-		v, err := strconv.ParseInt(s, 0, 0)
+		v, err := strconv.ParseInt(s, 10, 0)
 		if err == nil {
 			return int8(v), nil
 		}
@@ -399,7 +399,7 @@ func ToIntE(i interface{}) (int, error) {
 	case float32:
 		return int(s), nil
 	case string:
-		v, err := strconv.ParseInt(s, 0, 0)
+		v, err := strconv.ParseInt(s, 10, 0)
 		if err == nil {
 			return int(v), nil
 		}
@@ -422,7 +422,7 @@ func ToUintE(i interface{}) (uint, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseUint(s, 0, 0)
+		v, err := strconv.ParseUint(s, 10, 0)
 		if err == nil {
 			return uint(v), nil
 		}
@@ -490,7 +490,7 @@ func ToUint64E(i interface{}) (uint64, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseUint(s, 0, 64)
+		v, err := strconv.ParseUint(s, 10, 64)
 		if err == nil {
 			return v, nil
 		}
@@ -558,7 +558,7 @@ func ToUint32E(i interface{}) (uint32, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseUint(s, 0, 32)
+		v, err := strconv.ParseUint(s, 10, 32)
 		if err == nil {
 			return uint32(v), nil
 		}
@@ -626,7 +626,7 @@ func ToUint16E(i interface{}) (uint16, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseUint(s, 0, 16)
+		v, err := strconv.ParseUint(s, 10, 16)
 		if err == nil {
 			return uint16(v), nil
 		}
@@ -694,7 +694,7 @@ func ToUint8E(i interface{}) (uint8, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseUint(s, 0, 8)
+		v, err := strconv.ParseUint(s, 10, 8)
 		if err == nil {
 			return uint8(v), nil
 		}


### PR DESCRIPTION
Fixes issue #74 

It fixes the expected behavior of cast.ToInt() with a string prefixed with "0". 

Before this fix `cast.ToInt("01234")` results into `668` instead of `1234`.
Now it converts strings like "1234" and "01234" to 1234.

There should be a separate cast method for hex integers  like ("0x1234") like cast.ToHexInt("0x1234") e.g. if that is a must have.

