### PR TITLE
Add casting to url.URL

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -6,7 +6,10 @@
 // Package cast provides easy and safe casting in Go.
 package cast
 
-import "time"
+import (
+	"net/url"
+	"time"
+)
 
 // ToBool casts an interface to a bool type.
 func ToBool(i interface{}) bool {
@@ -17,6 +20,12 @@ func ToBool(i interface{}) bool {
 // ToTime casts an interface to a time.Time type.
 func ToTime(i interface{}) time.Time {
 	v, _ := ToTimeE(i)
+	return v
+}
+
+// ToURL casts an interface to a *url.URL type.
+func ToURL(i interface{}) *url.URL {
+	v, _ := ToURLE(i)
 	return v
 }
 

--- a/cast_test.go
+++ b/cast_test.go
@@ -8,6 +8,7 @@ package cast
 import (
 	"fmt"
 	"html/template"
+	"net/url"
 	"testing"
 	"time"
 

--- a/cast_test.go
+++ b/cast_test.go
@@ -1285,3 +1285,31 @@ func TestToDurationE(t *testing.T) {
 		assert.Equal(t, test.expect, v, errmsg)
 	}
 }
+
+func TestToURLE(t *testing.T) {
+	type args struct {
+		i interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantU   *url.URL
+		wantErr bool
+	}{
+		{"url", args{&url.URL{Scheme: "https", Host: "example.net", Path: "/"}}, &url.URL{Scheme: "https", Host: "example.net", Path: "/"}, false},
+		{"string", args{string("https://example.net/")}, &url.URL{Scheme: "https", Host: "example.net", Path: "/"}, false},
+		{"invalid", args{int(100)}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotU, err := ToURLE(tt.args.i)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToURLE() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotU, tt.wantU) {
+				t.Errorf("ToURLE() = %v, want %v", gotU, tt.wantU)
+			}
+		})
+	}
+}

--- a/caste.go
+++ b/caste.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
@@ -67,6 +68,20 @@ func ToDurationE(i interface{}) (d time.Duration, err error) {
 	default:
 		err = fmt.Errorf("unable to cast %#v of type %T to Duration", i, i)
 		return
+	}
+}
+
+// ToURLE casts an interface to a *url.URL type.
+func ToURLE(i interface{}) (u *url.URL, err error) {
+	i = indirect(i)
+
+	switch v := i.(type) {
+	case url.URL:
+		return &v, nil
+	case string:
+		return url.Parse(v)
+	default:
+		return nil, fmt.Errorf("unable to cast %#v of type %T to URL", i, i)
 	}
 }
 


### PR DESCRIPTION
Adds ToURL and ToURLE functions to cast an interface to a "*url.URL" type