### PR TITLE
Add convert any types code to ToStringMapE

### DIFF
--- a/cast_test.go
+++ b/cast_test.go
@@ -761,10 +761,14 @@ func TestToStringMapE(t *testing.T) {
 		{map[string]interface{}{"tag": "tags", "group": "groups"}, map[string]interface{}{"tag": "tags", "group": "groups"}, false},
 		{`{"tag": "tags", "group": "groups"}`, map[string]interface{}{"tag": "tags", "group": "groups"}, false},
 		{`{"tag": "tags", "group": true}`, map[string]interface{}{"tag": "tags", "group": true}, false},
-
+		{struct {
+			Hello string
+		}{
+			Hello: "World",
+		}, map[string]interface{}{"Hello": "World"}, false},
+		{testing.T{}, map[string]interface{}{}, false},
 		// errors
 		{nil, nil, true},
-		{testing.T{}, nil, true},
 		{"", nil, true},
 	}
 
@@ -772,6 +776,7 @@ func TestToStringMapE(t *testing.T) {
 		errmsg := fmt.Sprintf("i = %d", i) // assert helper message
 
 		v, err := ToStringMapE(test.input)
+		fmt.Printf("%+v", v)
 		if test.iserr {
 			assert.Error(t, err, errmsg)
 			continue

--- a/caste.go
+++ b/caste.go
@@ -986,7 +986,16 @@ func ToStringMapE(i interface{}) (map[string]interface{}, error) {
 		err := jsonStringToObject(v, &m)
 		return m, err
 	default:
-		return m, fmt.Errorf("unable to cast %#v of type %T to map[string]interface{}", i, i)
+		vo := reflect.ValueOf(i)
+		if vo.Kind() == reflect.Invalid {
+			return m, fmt.Errorf("unable to cast %#v of type %T to map[string]interface{}", i, i)
+		}
+		for i := 0; i < vo.NumField(); i++ {
+			if vo.Field(i).CanInterface() {
+				m[vo.Type().Field(i).Name] = vo.Field(i).Interface()
+			}
+		}
+		return m, nil
 	}
 }
 


### PR DESCRIPTION
**Add convert any types code to ToStringMapE**

This PR will add a convert code to ``ToStringMapE`` function for handle unexpected type such as any struct type

- [x] Add convert code into default section of switch condition of ``ToStringMapE`` function
- [x] Add new testcase to TestToStringMapE