### PR TITLE
[bugfix] parse unix timestamp to time.Time from string

### DIFF
--- a/caste.go
+++ b/caste.go
@@ -1273,6 +1273,10 @@ func parseDateWith(s string, dates []string) (d time.Time, e error) {
 			return
 		}
 	}
+	if i, err := strconv.Atoi(t); err == nil {
+		return time.Unix(int64(i), 0), nil
+	}
+
 	return d, fmt.Errorf("unable to parse date: %s", s)
 }
 


### PR DESCRIPTION
Fixing https://github.com/spf13/cast/issues/102