### PR TITLE
Add support for git's human format

### DIFF
--- a/cast_test.go
+++ b/cast_test.go
@@ -1206,6 +1206,7 @@ func TestToTimeEE(t *testing.T) {
 		{"Nov 10 23:00:00.000000000", time.Date(0, 11, 10, 23, 0, 0, 0, time.UTC), false},          // StampNano
 		{"2016-03-06 15:28:01-00:00", time.Date(2016, 3, 6, 15, 28, 1, 0, time.UTC), false},        // RFC3339 without T
 		{"2016-03-06 15:28:01-0000", time.Date(2016, 3, 6, 15, 28, 1, 0, time.UTC), false},         // RFC3339 without T or timezone hh:mm colon
+		{"Fri Sep 25 13:58:21 2020 -0400", time.Date(2020, 9, 25, 17, 58, 21, 0, time.UTC), false}, // git's human log format
 		{"2016-03-06 15:28:01", time.Date(2016, 3, 6, 15, 28, 1, 0, time.UTC), false},
 		{"2016-03-06 15:28:01 -0000", time.Date(2016, 3, 6, 15, 28, 1, 0, time.UTC), false},
 		{"2016-03-06 15:28:01 -00:00", time.Date(2016, 3, 6, 15, 28, 1, 0, time.UTC), false},

--- a/caste.go
+++ b/caste.go
@@ -1264,6 +1264,7 @@ func StringToDate(s string) (time.Time, error) {
 		time.StampMilli,
 		time.StampMicro,
 		time.StampNano,
+		"Mon Jan 2 15:04:05 2006 -0700", // git's human log format
 	})
 }
 


### PR DESCRIPTION
Git log by default uses it's own human format [Sat May 8 19:35:34 2010 -0500][1]. This adds support for parsing this format.

[1]: https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-log.html