### PR TITLE
fix ToInt64E to cast value to int64 correctly on 32-bit system

### DIFF
--- a/caste.go
+++ b/caste.go
@@ -211,7 +211,7 @@ func ToInt64E(i interface{}) (int64, error) {
 	case float32:
 		return int64(s), nil
 	case string:
-		v, err := strconv.ParseInt(s, 0, 0)
+		v, err := strconv.ParseInt(s, 0, 64)
 		if err == nil {
 			return v, nil
 		}


### PR DESCRIPTION
ToInt64E currently try cast the value to int type, which default to int32 type
on 32-bit system and will result in potential overflow error. Fix this by
update the bitSize to 64 to cast the value to int64 on any system.