### PR TITLE
add support to cast uint slices

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -163,6 +163,12 @@ func ToStringSlice(i interface{}) []string {
 	return v
 }
 
+// ToUintSlice casts an interface to a []uint type.
+func ToUintSlice(i interface{}) []uint {
+	v, _ := ToUintSliceE(i)
+	return v
+}
+
 // ToIntSlice casts an interface to a []int type.
 func ToIntSlice(i interface{}) []int {
 	v, _ := ToIntSliceE(i)

--- a/cast_test.go
+++ b/cast_test.go
@@ -980,6 +980,40 @@ func TestToBoolSliceE(t *testing.T) {
 	}
 }
 
+func TestToUintSliceE(t *testing.T) {
+	tests := []struct {
+		input  interface{}
+		expect []uint
+		iserr  bool
+	}{
+		{[]uint{1, 3}, []uint{1, 3}, false},
+		{[]interface{}{1.2, 3.2}, []uint{1, 3}, false},
+		{[]string{"2", "3"}, []uint{2, 3}, false},
+		{[2]string{"2", "3"}, []uint{2, 3}, false},
+		// errors
+		{nil, nil, true},
+		{testing.T{}, nil, true},
+		{[]string{"foo", "bar"}, nil, true},
+	}
+
+	for i, test := range tests {
+		errmsg := fmt.Sprintf("i = %d", i) // assert helper message
+
+		v, err := ToUintSliceE(test.input)
+		if test.iserr {
+			assert.Error(t, err, errmsg)
+			continue
+		}
+
+		assert.NoError(t, err, errmsg)
+		assert.Equal(t, test.expect, v, errmsg)
+
+		// Non-E test
+		v = ToUintSlice(test.input)
+		assert.Equal(t, test.expect, v, errmsg)
+	}
+}
+
 func TestToIntSliceE(t *testing.T) {
 	tests := []struct {
 		input  interface{}

--- a/cast_test.go
+++ b/cast_test.go
@@ -993,6 +993,8 @@ func TestToUintSliceE(t *testing.T) {
 		// errors
 		{nil, nil, true},
 		{testing.T{}, nil, true},
+		{[]interface{}{-1, 2}, nil, true},
+		{[]string{"-2", "-3"}, nil, true},
 		{[]string{"foo", "bar"}, nil, true},
 	}
 

--- a/caste.go
+++ b/caste.go
@@ -1213,7 +1213,6 @@ func ToUintSliceE(i interface{}) ([]uint, error) {
 	}
 }
 
-
 // ToIntSliceE casts an interface to a []int type.
 func ToIntSliceE(i interface{}) ([]int, error) {
 	if i == nil {

--- a/caste.go
+++ b/caste.go
@@ -1184,6 +1184,36 @@ func ToStringSliceE(i interface{}) ([]string, error) {
 	}
 }
 
+// ToUintSliceE casts an interface to a []uint type.
+func ToUintSliceE(i interface{}) ([]uint, error) {
+	if i == nil {
+		return []uint{}, fmt.Errorf("unable to cast %#v of type %T to []uint", i, i)
+	}
+
+	switch v := i.(type) {
+	case []uint:
+		return v, nil
+	}
+
+	kind := reflect.TypeOf(i).Kind()
+	switch kind {
+	case reflect.Slice, reflect.Array:
+		s := reflect.ValueOf(i)
+		a := make([]uint, s.Len())
+		for j := 0; j < s.Len(); j++ {
+			val, err := ToUintE(s.Index(j).Interface())
+			if err != nil {
+				return []uint{}, fmt.Errorf("unable to cast %#v of type %T to []uint", i, i)
+			}
+			a[j] = val
+		}
+		return a, nil
+	default:
+		return []uint{}, fmt.Errorf("unable to cast %#v of type %T to []uint", i, i)
+	}
+}
+
+
 // ToIntSliceE casts an interface to a []int type.
 func ToIntSliceE(i interface{}) ([]int, error) {
 	if i == nil {


### PR DESCRIPTION
### What does this MR does?

Create `ToUintSliceE` and `ToUintSlice` method to support uint slice casting;

### How to test?

- Run the unit tests:
```shell
go test -v  -run TestToUintSliceE .
```

- Test code:
```go
input := []interface{}{1.2, 3.2}
v = ToUintSlice(input)
fmt.Println(v)
```