### PR TITLE
add support to cast uint32 slices

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -163,6 +163,12 @@ func ToStringSlice(i interface{}) []string {
 	return v
 }
 
+// ToUint32Slice casts an interface to a []uint32 type.
+func ToUint32Slice(i interface{}) []uint32 {
+	v, _ := ToUint32SliceE(i)
+	return v
+}
+
 // ToIntSlice casts an interface to a []int type.
 func ToIntSlice(i interface{}) []int {
 	v, _ := ToIntSliceE(i)

--- a/cast_test.go
+++ b/cast_test.go
@@ -993,6 +993,8 @@ func TestToUint32SliceE(t *testing.T) {
 		// errors
 		{nil, nil, true},
 		{testing.T{}, nil, true},
+		{[]interface{}{-1, 2}, nil, true},
+		{[]string{"-2", "-3"}, nil, true},
 		{[]string{"foo", "bar"}, nil, true},
 	}
 

--- a/cast_test.go
+++ b/cast_test.go
@@ -980,7 +980,7 @@ func TestToBoolSliceE(t *testing.T) {
 	}
 }
 
-func TestToUintSliceE(t *testing.T) {
+func TestToUint32SliceE(t *testing.T) {
 	tests := []struct {
 		input  interface{}
 		expect []uint32

--- a/cast_test.go
+++ b/cast_test.go
@@ -980,6 +980,40 @@ func TestToBoolSliceE(t *testing.T) {
 	}
 }
 
+func TestToUintSliceE(t *testing.T) {
+	tests := []struct {
+		input  interface{}
+		expect []uint32
+		iserr  bool
+	}{
+		{[]uint32{1, 3}, []uint32{1, 3}, false},
+		{[]interface{}{1.2, 3.2}, []uint32{1, 3}, false},
+		{[]string{"2", "3"}, []uint32{2, 3}, false},
+		{[2]string{"2", "3"}, []uint32{2, 3}, false},
+		// errors
+		{nil, nil, true},
+		{testing.T{}, nil, true},
+		{[]string{"foo", "bar"}, nil, true},
+	}
+
+	for i, test := range tests {
+		errmsg := fmt.Sprintf("i = %d", i) // assert helper message
+
+		v, err := ToUint32SliceE(test.input)
+		if test.iserr {
+			assert.Error(t, err, errmsg)
+			continue
+		}
+
+		assert.NoError(t, err, errmsg)
+		assert.Equal(t, test.expect, v, errmsg)
+
+		// Non-E test
+		v = ToUint32Slice(test.input)
+		assert.Equal(t, test.expect, v, errmsg)
+	}
+}
+
 func TestToIntSliceE(t *testing.T) {
 	tests := []struct {
 		input  interface{}

--- a/caste.go
+++ b/caste.go
@@ -1184,6 +1184,35 @@ func ToStringSliceE(i interface{}) ([]string, error) {
 	}
 }
 
+// ToUint32SliceE casts an interface to a []uint32 type.
+func ToUint32SliceE(i interface{}) ([]uint32, error) {
+	if i == nil {
+		return []uint32{}, fmt.Errorf("unable to cast %#v of type %T to []uint32", i, i)
+	}
+
+	switch v := i.(type) {
+	case []uint32:
+		return v, nil
+	}
+
+	kind := reflect.TypeOf(i).Kind()
+	switch kind {
+	case reflect.Slice, reflect.Array:
+		s := reflect.ValueOf(i)
+		a := make([]uint32, s.Len())
+		for j := 0; j < s.Len(); j++ {
+			val, err := ToUint32E(s.Index(j).Interface())
+			if err != nil {
+				return []uint32{}, fmt.Errorf("unable to cast %#v of type %T to []uint32", i, i)
+			}
+			a[j] = val
+		}
+		return a, nil
+	default:
+		return []uint32{}, fmt.Errorf("unable to cast %#v of type %T to []uint32", i, i)
+	}
+}
+
 // ToIntSliceE casts an interface to a []int type.
 func ToIntSliceE(i interface{}) ([]int, error) {
 	if i == nil {


### PR DESCRIPTION
### What does this MR does?

Create `ToUint32SliceE` and `ToUint32Slice` method to support uint32 slice casting;

### How to test?

- Run the unit tests:
```shell
go test -v  -run TestToUint32SliceE .
```

- Test code:
```go
input := []interface{}{1.2, 3.2}
v = ToUint32Slice(input)
fmt.Println(v)
```