### PR TITLE
Implement ToSizeInBytes(E)

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -25,6 +25,12 @@ func ToTimeInDefaultLocation(i interface{}, location *time.Location) time.Time {
 	return v
 }
 
+// ToSizeInBytes casts an interface to the uint size in bytes.
+func ToSizeInBytes(i interface{}) uint {
+	v, _ := ToSizeInBytesE(i)
+	return v
+}
+
 // ToDuration casts an interface to a time.Duration type.
 func ToDuration(i interface{}) time.Duration {
 	v, _ := ToDurationE(i)


### PR DESCRIPTION
Allow to convert string with size units (such as "10kb") to bytes.
This converter is privately used in viper. I think it is great to
allow using it from cast. Compared to viper implementation this one
allows to have single-letter suffixes.

Signed-off-by: Evgenii Stratonikov <stratonikov@runbox.com>