### PR TITLE
Support more types for convert ToBool

### DIFF
--- a/caste.go
+++ b/caste.go
@@ -91,6 +91,51 @@ func ToBoolE(i interface{}) (bool, error) {
 			return true, nil
 		}
 		return false, nil
+	case int8:
+		if i.(int8) != 0 {
+			return true, nil
+		}
+		return false, nil
+	case int16:
+		if i.(int16) != 0 {
+			return true, nil
+		}
+		return false, nil
+	case int32:
+		if i.(int32) != 0 {
+			return true, nil
+		}
+		return false, nil
+	case int64:
+		if i.(int64) != 0 {
+			return true, nil
+		}
+		return false, nil
+	case uint:
+		if i.(uint) > 0 {
+			return true, nil
+		}
+		return false, nil
+	case uint8:
+		if i.(uint8) > 0 {
+			return true, nil
+		}
+		return false, nil
+	case uint16:
+		if i.(uint16) > 0 {
+			return true, nil
+		}
+		return false, nil
+	case uint32:
+		if i.(uint32) > 0 {
+			return true, nil
+		}
+		return false, nil
+	case uint64:
+		if i.(uint64) > 0 {
+			return true, nil
+		}
+		return false, nil
 	case string:
 		return strconv.ParseBool(i.(string))
 	default:


### PR DESCRIPTION
I find it weird for function converting ToBool to work with int but unable to convert int64, so I think we should add some more.
Types added:
- int8
- int16
- int32
- int64
- uint
- uint8
- uint16
- uint32
- uint64