### PR TITLE
Add function to cast `interface{}` to `[]float64`

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -169,6 +169,12 @@ func ToIntSlice(i interface{}) []int {
 	return v
 }
 
+// ToFloat64Slice casts an interface to a []float64 type.
+func ToFloat64Slice(i interface{}) []float64 {
+	v, _ := ToFloat64SliceE(i)
+	return v
+}
+
 // ToDurationSlice casts an interface to a []time.Duration type.
 func ToDurationSlice(i interface{}) []time.Duration {
 	v, _ := ToDurationSliceE(i)

--- a/cast_test.go
+++ b/cast_test.go
@@ -678,6 +678,45 @@ func TestToIntSliceE(t *testing.T) {
 	}
 }
 
+func TestToFloat64SliceE(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		input  interface{}
+		expect []float64
+		iserr  bool
+	}{
+		{[]int{1, 3}, []float64{1, 3}, false},
+		{[]float64{1.2, 3.2}, []float64{1.2, 3.2}, false},
+		{[]interface{}{1.2, 3.2}, []float64{1.2, 3.2}, false},
+		{[]string{"2", "3"}, []float64{2, 3}, false},
+		{[]string{"1.2", "3.2"}, []float64{1.2, 3.2}, false},
+		{[2]string{"2", "3"}, []float64{2, 3}, false},
+		{[2]string{"1.2", "3.2"}, []float64{1.2, 3.2}, false},
+		// errors
+		{nil, nil, true},
+		{testing.T{}, nil, true},
+		{[]string{"foo", "bar"}, nil, true},
+	}
+
+	for i, test := range tests {
+		errmsg := qt.Commentf("i = %d", i) // assert helper message
+
+		v, err := ToFloat64SliceE(test.input)
+		if test.iserr {
+			c.Assert(err, qt.IsNotNil)
+			continue
+		}
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(v, qt.DeepEquals, test.expect, errmsg)
+
+		// Non-E test
+		v = ToFloat64Slice(test.input)
+		c.Assert(v, qt.DeepEquals, test.expect, errmsg)
+	}
+}
+
 func TestToSliceE(t *testing.T) {
 	c := qt.New(t)
 

--- a/caste.go
+++ b/caste.go
@@ -1329,6 +1329,11 @@ func ToIntSliceE(i interface{}) ([]int, error) {
 	return toSliceE(i, ToIntE)
 }
 
+// ToFloat64SliceE casts an interface to a []float64 type.
+func ToFloat64SliceE(i interface{}) ([]float64, error) {
+	return toSliceE(i, ToFloat64E)
+}
+
 // ToDurationSliceE casts an interface to a []time.Duration type.
 func ToDurationSliceE(i interface{}) ([]time.Duration, error) {
 	return toSliceE(i, ToDurationE)


### PR DESCRIPTION
Fixes #176 by adding the `ToFloat64Slice()` and `ToFloat64SliceE()` helper functions.