### PR TITLE
Fix that when calling the cast.ToInt function to pass in a string wit…

### DIFF
--- a/caste.go
+++ b/caste.go
@@ -281,7 +281,7 @@ func ToInt64E(i interface{}) (int64, error) {
 	case float32:
 		return int64(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 64)
 		if err == nil {
 			return v, nil
 		}
@@ -333,7 +333,7 @@ func ToInt32E(i interface{}) (int32, error) {
 	case float32:
 		return int32(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 64)
 		if err == nil {
 			return int32(v), nil
 		}
@@ -385,7 +385,7 @@ func ToInt16E(i interface{}) (int16, error) {
 	case float32:
 		return int16(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 64)
 		if err == nil {
 			return int16(v), nil
 		}
@@ -437,7 +437,7 @@ func ToInt8E(i interface{}) (int8, error) {
 	case float32:
 		return int8(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 64)
 		if err == nil {
 			return int8(v), nil
 		}
@@ -489,7 +489,7 @@ func ToIntE(i interface{}) (int, error) {
 	case float32:
 		return int(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 64)
 		if err == nil {
 			return int(v), nil
 		}
@@ -522,7 +522,7 @@ func ToUintE(i interface{}) (uint, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 64)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
@@ -598,7 +598,7 @@ func ToUint64E(i interface{}) (uint64, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 64)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
@@ -674,7 +674,7 @@ func ToUint32E(i interface{}) (uint32, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 64)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
@@ -750,7 +750,7 @@ func ToUint16E(i interface{}) (uint16, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 64)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
@@ -826,7 +826,7 @@ func ToUint8E(i interface{}) (uint8, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 64)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed


### PR DESCRIPTION
Fix that when calling the cast.ToInt function to pass in a string with a value of 08 or 09, the expected return values 8 and 9 were not returned correctly, returning 0