### PR TITLE
string float act like float when converted to int*

### DIFF
--- a/caste.go
+++ b/caste.go
@@ -281,7 +281,7 @@ func ToInt64E(i interface{}) (int64, error) {
 	case float32:
 		return int64(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(truncateDecimals(trimZeroDecimal(s)), 0, 0)
 		if err == nil {
 			return v, nil
 		}
@@ -333,7 +333,7 @@ func ToInt32E(i interface{}) (int32, error) {
 	case float32:
 		return int32(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(truncateDecimals(trimZeroDecimal(s)), 0, 0)
 		if err == nil {
 			return int32(v), nil
 		}
@@ -385,7 +385,7 @@ func ToInt16E(i interface{}) (int16, error) {
 	case float32:
 		return int16(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(truncateDecimals(trimZeroDecimal(s)), 0, 0)
 		if err == nil {
 			return int16(v), nil
 		}
@@ -437,7 +437,7 @@ func ToInt8E(i interface{}) (int8, error) {
 	case float32:
 		return int8(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(truncateDecimals(trimZeroDecimal(s)), 0, 0)
 		if err == nil {
 			return int8(v), nil
 		}
@@ -489,7 +489,7 @@ func ToIntE(i interface{}) (int, error) {
 	case float32:
 		return int(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(truncateDecimals(trimZeroDecimal(s)), 0, 0)
 		if err == nil {
 			return int(v), nil
 		}
@@ -522,7 +522,7 @@ func ToUintE(i interface{}) (uint, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(truncateDecimals(trimZeroDecimal(s)), 0, 0)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
@@ -598,7 +598,7 @@ func ToUint64E(i interface{}) (uint64, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(truncateDecimals(trimZeroDecimal(s)), 0, 0)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
@@ -674,7 +674,7 @@ func ToUint32E(i interface{}) (uint32, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(truncateDecimals(trimZeroDecimal(s)), 0, 0)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
@@ -750,7 +750,7 @@ func ToUint16E(i interface{}) (uint16, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(truncateDecimals(trimZeroDecimal(s)), 0, 0)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
@@ -826,7 +826,7 @@ func ToUint8E(i interface{}) (uint8, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(truncateDecimals(trimZeroDecimal(s)), 0, 0)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
@@ -1495,4 +1495,30 @@ func trimZeroDecimal(s string) string {
 		}
 	}
 	return s
+}
+
+func truncateDecimals(s string) string {
+	v := -1
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '.' {
+			v = i
+			break
+		}
+	}
+	if v == -1 {
+		return s
+	}
+	for i := len(s) - 1; i > v; i-- {
+		if s[i] < '0' || s[i] > '9' {
+			return s
+		}
+	}
+	for i := v - 1; i >= 0; i-- {
+		if s[i] < '0' || s[i] > '9' {
+			if i != 0 || (s[i] != '+' && s[i] != '-') {
+				return s
+			}
+		}
+	}
+	return s[:v]
 }


### PR DESCRIPTION
#204 #172 

built in:
cast.ToInt64E(float64(8.2)) => 8

previously:
cast.ToInt64E(string("8.2")) => unable to cast "8.2" of type string to int64

more expected:
cast.ToInt64E(string("8.2")) => 8

If you agree with my thoughts or have a better understanding, feel free to leave a comment for discussion.