### PR TITLE
Fix ToUint64 issue with string input exceeding maximum int64

### DIFF
--- a/cast_test.go
+++ b/cast_test.go
@@ -111,6 +111,12 @@ func TestToUintE(t *testing.T) {
 func TestToUint64E(t *testing.T) {
 	tests := createNumberTestSteps(uint64(0), uint64(1), uint64(8), uint64(0), uint64(8), uint64(8))
 
+	// Maximum value of uint64
+	tests = append(tests,
+		testStep{"18446744073709551615", uint64(18446744073709551615), false},
+		testStep{"18446744073709551616", uint64(0), true},
+	)
+
 	runNumberTest(
 		qt.New(t),
 		tests,

--- a/caste.go
+++ b/caste.go
@@ -598,12 +598,12 @@ func ToUint64E(i interface{}) (uint64, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseUint(trimZeroDecimal(s), 0, 0)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
 			}
-			return uint64(v), nil
+			return v, nil
 		}
 		return 0, fmt.Errorf("unable to cast %#v of type %T to uint64", i, i)
 	case json.Number:


### PR DESCRIPTION
#211 
The ToUint64E function was fixed to correctly handle strings that overflow the maximum value of int64.

Previously, the function incorrectly returned zero for these input values because it was using strconv.ParseInt internally, which doesn't handle values greater than the max int64.

The fix replaces the use of strconv.ParseInt with strconv.ParseUint.