### PR TITLE
Convert string slice to string using strings.Join(s, ",").

### DIFF
--- a/caste.go
+++ b/caste.go
@@ -964,6 +964,8 @@ func ToStringE(i interface{}) (string, error) {
 		return s.String(), nil
 	case []byte:
 		return string(s), nil
+	case []string:
+		return strings.Join(s, ","), nil
 	case template.HTML:
 		return string(s), nil
 	case template.URL:


### PR DESCRIPTION
Hi!

In this PR, I added support to convert string slice to string using `strings.Join(s, ",")`.
I was experimenting yesterday with some code based on `spf13/viper` and was surprised to get an empty string as result of calling `GetString()` on a config key I know was a string slice.
Moreover, I did not get any error message, as `GetString()` did not return one:
https://github.com/spf13/viper/blob/551e8939be1e18c45accb6d144e6c19e46ee24e1/viper.go#L785-L787

As I think this code may be useful for other people, I decided to open a PR.
Please let me know what you think about it.

Best regards.