### PR TITLE
Fix Conversion of String Values with Leading Zeros

### DIFF
--- a/caste.go
+++ b/caste.go
@@ -296,7 +296,7 @@ func ToInt64E(i interface{}) (int64, error) {
 	case float32:
 		return int64(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 0)
 		if err == nil {
 			return v, nil
 		}
@@ -348,7 +348,7 @@ func ToInt32E(i interface{}) (int32, error) {
 	case float32:
 		return int32(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 0)
 		if err == nil {
 			return int32(v), nil
 		}
@@ -400,7 +400,7 @@ func ToInt16E(i interface{}) (int16, error) {
 	case float32:
 		return int16(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 0)
 		if err == nil {
 			return int16(v), nil
 		}
@@ -452,7 +452,7 @@ func ToInt8E(i interface{}) (int8, error) {
 	case float32:
 		return int8(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 0)
 		if err == nil {
 			return int8(v), nil
 		}
@@ -504,7 +504,7 @@ func ToIntE(i interface{}) (int, error) {
 	case float32:
 		return int(s), nil
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 0)
 		if err == nil {
 			return int(v), nil
 		}
@@ -537,7 +537,7 @@ func ToUintE(i interface{}) (uint, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 0)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
@@ -613,7 +613,7 @@ func ToUint64E(i interface{}) (uint64, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 0)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
@@ -689,7 +689,7 @@ func ToUint32E(i interface{}) (uint32, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 0)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
@@ -765,7 +765,7 @@ func ToUint16E(i interface{}) (uint16, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 0)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
@@ -841,7 +841,7 @@ func ToUint8E(i interface{}) (uint8, error) {
 
 	switch s := i.(type) {
 	case string:
-		v, err := strconv.ParseInt(trimZeroDecimal(s), 0, 0)
+		v, err := strconv.ParseInt(trimZeroDecimal(s), 10, 0)
 		if err == nil {
 			if v < 0 {
 				return 0, errNegativeNotAllowed
@@ -911,6 +911,7 @@ func indirect(a interface{}) interface{} {
 	if a == nil {
 		return nil
 	}
+	
 	if t := reflect.TypeOf(a); t.Kind() != reflect.Ptr {
 		// Avoid creating a reflect.Value if it's not a pointer.
 		return a


### PR DESCRIPTION
#220 
This PR addresses an issue where cast.ToInt returned 0 when converting string values with leading zeros, such as "08", instead of the expected integer. The issue has been identified and resolved by ensuring that strings with leading zeros correctly convert to their corresponding integer values.