### PR TITLE
Improve ToString/ToStringE performance

### DIFF
--- a/cast_test.go
+++ b/cast_test.go
@@ -280,18 +280,27 @@ func TestToStringE(t *testing.T) {
 	for i, test := range tests {
 		errmsg := qt.Commentf("i = %d", i) // assert helper message
 
+		// Non-E test
+		v := ToString(test.input)
+		c.Assert(v, qt.Equals, test.expect, errmsg)
+
+		// Non-pointer test
 		v, err := ToStringE(test.input)
 		if test.iserr {
 			c.Assert(err, qt.IsNotNil, errmsg)
-			continue
+		} else {
+			c.Assert(err, qt.IsNil, errmsg)
+			c.Assert(v, qt.Equals, test.expect, errmsg)
 		}
 
-		c.Assert(err, qt.IsNil, errmsg)
-		c.Assert(v, qt.Equals, test.expect, errmsg)
-
-		// Non-E test
-		v = ToString(test.input)
-		c.Assert(v, qt.Equals, test.expect, errmsg)
+		// Pointer test
+		v, err = ToStringE(&test.input)
+		if test.iserr {
+			c.Assert(err, qt.IsNotNil, errmsg)
+		} else {
+			c.Assert(err, qt.IsNil, errmsg)
+			c.Assert(v, qt.Equals, test.expect, errmsg)
+		}
 	}
 }
 
@@ -308,7 +317,8 @@ func TestStringerToString(t *testing.T) {
 
 	var x foo
 	x.val = "bar"
-	c.Assert(ToString(x), qt.Equals, "bar")
+	c.Assert(ToString(x), qt.Equals, "bar", qt.Commentf("non-pointer test"))
+	c.Assert(ToString(&x), qt.Equals, "bar", qt.Commentf("pointer test"))
 }
 
 type fu struct {
@@ -324,7 +334,8 @@ func TestErrorToString(t *testing.T) {
 
 	var x fu
 	x.val = "bar"
-	c.Assert(ToString(x), qt.Equals, "bar")
+	c.Assert(ToString(x), qt.Equals, "bar", qt.Commentf("non-pointer test"))
+	c.Assert(ToString(&x), qt.Equals, "bar", qt.Commentf("pointer test"))
 }
 
 func TestStringMapStringSliceE(t *testing.T) {

--- a/caste.go
+++ b/caste.go
@@ -919,30 +919,8 @@ func indirect(a interface{}) interface{} {
 	return v.Interface()
 }
 
-// From html/template/content.go
-// Copyright 2011 The Go Authors. All rights reserved.
-// indirectToStringerOrError returns the value, after dereferencing as many times
-// as necessary to reach the base type (or nil) or an implementation of fmt.Stringer
-// or error,
-func indirectToStringerOrError(a interface{}) interface{} {
-	if a == nil {
-		return nil
-	}
-
-	errorType := reflect.TypeOf((*error)(nil)).Elem()
-	fmtStringerType := reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
-
-	v := reflect.ValueOf(a)
-	for !v.Type().Implements(fmtStringerType) && !v.Type().Implements(errorType) && v.Kind() == reflect.Ptr && !v.IsNil() {
-		v = v.Elem()
-	}
-	return v.Interface()
-}
-
 // ToStringE casts an interface to a string type.
 func ToStringE(i interface{}) (string, error) {
-	i = indirectToStringerOrError(i)
-
 	switch s := i.(type) {
 	case string:
 		return s, nil
@@ -993,6 +971,11 @@ func ToStringE(i interface{}) (string, error) {
 	case error:
 		return s.Error(), nil
 	default:
+		v := reflect.ValueOf(s)
+		for v.Kind() == reflect.Ptr && !v.IsNil() {
+			return ToStringE(v.Elem().Interface())
+		}
+
 		return "", fmt.Errorf("unable to cast %#v of type %T to string", i, i)
 	}
 }


### PR DESCRIPTION
Currently `ToString`/`ToStringE` always attempts to perform pointer dereference before the type checks which adds significant overhead when casting non-pointer values (_for pointers it is also not very optimal because the reflection of `errorType` and `fmtStringerType` would be evaluated on every `ToString`/`ToStringE` call_).


This PR:
- moves the pointer check in the `default` clause and calls `ToStringE` with its underlying value
- updates the existing tests with equivalent checks for pointers

Below are some basic benchmark results from my local environment (_the best from 3 consequent runs_):

1. **Plain value**
    ```go
    func BenchmarkToString(b *testing.B) {
        for range b.N {
            cast.ToString("test")
        }
    }
    ```
    ```
    // Old:
    BenchmarkToString-4     19877439          60.69 ns/op
    
    // New:
    BenchmarkToString-4     282848110         4.364 ns/op
    ```

2. **Pointer**
    ```go
    func BenchmarkToString(b *testing.B) {
        v := "test"
        for range b.N {
            cast.ToString(&v)
        }
    }
    ```
    ```
    // Old:
    BenchmarkToString-4      4797831         287.2 ns/op

    // New:
    BenchmarkToString-4     10021204         216.1 ns/op
    ```
