### PR TITLE
Added ToBase<Int|Uint|etc>() functions for ToBaseInt('08', 10) => 8 (Fixes #232)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 # Folders
 _obj
 _test
+.idea
+
+# Files
+.DS_Store
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ the code for a complete set.
     cast.ToInt(eight)              // 8
     cast.ToInt(nil)                // 0
 
+### Example 'ToBaseInt':
+
+    cast.ToBaseInt(8, 10)          // 8
+    cast.ToBaseInt(8, 16)          // 8
+    cast.ToBaseInt(8, 2)           // 1000
+    cast.ToBaseInt("08", 10)       // 8
+
 ## License
 
 The project is licensed under the [MIT License](LICENSE).

--- a/cast.go
+++ b/cast.go
@@ -43,6 +43,66 @@ func ToFloat32(i interface{}) float32 {
 	return v
 }
 
+// ToBaseInt64 casts an interface to an int64 type.
+func ToBaseInt64(i interface{}, base int) int64 {
+	v, _ := ToInt64EB(i, base)
+	return v
+}
+
+// ToBaseInt32 casts an interface to an int32 type.
+func ToBaseInt32(i interface{}, base int) int32 {
+	v, _ := ToInt32EB(i, base)
+	return v
+}
+
+// ToBaseInt16 casts an interface to an int16 type.
+func ToBaseInt16(i interface{}, base int) int16 {
+	v, _ := ToInt16EB(i, base)
+	return v
+}
+
+// ToBaseInt8 casts an interface to an int8 type.
+func ToBaseInt8(i interface{}, base int) int8 {
+	v, _ := ToInt8EB(i, base)
+	return v
+}
+
+// ToBaseInt casts an interface to an int type.
+func ToBaseInt(i interface{}, base int) int {
+	v, _ := ToIntEB(i, base)
+	return v
+}
+
+// ToBaseUint casts an interface to a uint type.
+func ToBaseUint(i interface{}, base int) uint {
+	v, _ := ToUintEB(i, base)
+	return v
+}
+
+// ToBaseUint64 casts an interface to a uint64 type.
+func ToBaseUint64(i interface{}, base int) uint64 {
+	v, _ := ToUint64EB(i, base)
+	return v
+}
+
+// ToBaseUint32 casts an interface to a uint32 type.
+func ToBaseUint32(i interface{}, base int) uint32 {
+	v, _ := ToUint32EB(i, base)
+	return v
+}
+
+// ToBaseUint16 casts an interface to a uint16 type.
+func ToBaseUint16(i interface{}, base int) uint16 {
+	v, _ := ToUint16EB(i, base)
+	return v
+}
+
+// ToBaseUint8 casts an interface to a uint8 type.
+func ToBaseUint8(i interface{}, base int) uint8 {
+	v, _ := ToUint8EB(i, base)
+	return v
+}
+
 // ToInt64 casts an interface to an int64 type.
 func ToInt64(i interface{}) int64 {
 	v, _ := ToInt64E(i)

--- a/caste.go
+++ b/caste.go
@@ -315,6 +315,58 @@ func ToInt64E(i interface{}) (int64, error) {
 	}
 }
 
+// ToInt64EB casts an interface to an int64 type.
+func ToInt64EB(i interface{}, b int) (int64, error) {
+	i = indirect(i)
+
+	intv, ok := toInt(i)
+	if ok {
+		return int64(intv), nil
+	}
+
+	switch s := i.(type) {
+	case int64:
+		return s, nil
+	case int32:
+		return int64(s), nil
+	case int16:
+		return int64(s), nil
+	case int8:
+		return int64(s), nil
+	case uint:
+		return int64(s), nil
+	case uint64:
+		return int64(s), nil
+	case uint32:
+		return int64(s), nil
+	case uint16:
+		return int64(s), nil
+	case uint8:
+		return int64(s), nil
+	case float64:
+		return int64(s), nil
+	case float32:
+		return int64(s), nil
+	case string:
+		v, err := strconv.ParseInt(trimZeroDecimal(s), b, 0)
+		if err == nil {
+			return v, nil
+		}
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to int64", i, i, b)
+	case json.Number:
+		return ToInt64EB(string(s), b)
+	case bool:
+		if s {
+			return 1, nil
+		}
+		return 0, nil
+	case nil:
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to int64", i, i, b)
+	}
+}
+
 // ToInt32E casts an interface to an int32 type.
 func ToInt32E(i interface{}) (int32, error) {
 	i = indirect(i)
@@ -364,6 +416,58 @@ func ToInt32E(i interface{}) (int32, error) {
 		return 0, nil
 	default:
 		return 0, fmt.Errorf("unable to cast %#v of type %T to int32", i, i)
+	}
+}
+
+// ToInt32EB casts an interface to an int32 type.
+func ToInt32EB(i interface{}, b int) (int32, error) {
+	i = indirect(i)
+
+	intv, ok := toInt(i)
+	if ok {
+		return int32(intv), nil
+	}
+
+	switch s := i.(type) {
+	case int64:
+		return int32(s), nil
+	case int32:
+		return s, nil
+	case int16:
+		return int32(s), nil
+	case int8:
+		return int32(s), nil
+	case uint:
+		return int32(s), nil
+	case uint64:
+		return int32(s), nil
+	case uint32:
+		return int32(s), nil
+	case uint16:
+		return int32(s), nil
+	case uint8:
+		return int32(s), nil
+	case float64:
+		return int32(s), nil
+	case float32:
+		return int32(s), nil
+	case string:
+		v, err := strconv.ParseInt(trimZeroDecimal(s), b, 0)
+		if err == nil {
+			return int32(v), nil
+		}
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to int32", i, i, b)
+	case json.Number:
+		return ToInt32EB(string(s), b)
+	case bool:
+		if s {
+			return 1, nil
+		}
+		return 0, nil
+	case nil:
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to int32", i, i, b)
 	}
 }
 
@@ -419,6 +523,58 @@ func ToInt16E(i interface{}) (int16, error) {
 	}
 }
 
+// ToInt16EB casts an interface to an int16 type.
+func ToInt16EB(i interface{}, b int) (int16, error) {
+	i = indirect(i)
+
+	intv, ok := toInt(i)
+	if ok {
+		return int16(intv), nil
+	}
+
+	switch s := i.(type) {
+	case int64:
+		return int16(s), nil
+	case int32:
+		return int16(s), nil
+	case int16:
+		return s, nil
+	case int8:
+		return int16(s), nil
+	case uint:
+		return int16(s), nil
+	case uint64:
+		return int16(s), nil
+	case uint32:
+		return int16(s), nil
+	case uint16:
+		return int16(s), nil
+	case uint8:
+		return int16(s), nil
+	case float64:
+		return int16(s), nil
+	case float32:
+		return int16(s), nil
+	case string:
+		v, err := strconv.ParseInt(trimZeroDecimal(s), b, 0)
+		if err == nil {
+			return int16(v), nil
+		}
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to int16", i, i, b)
+	case json.Number:
+		return ToInt16EB(string(s), b)
+	case bool:
+		if s {
+			return 1, nil
+		}
+		return 0, nil
+	case nil:
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to int16", i, i, b)
+	}
+}
+
 // ToInt8E casts an interface to an int8 type.
 func ToInt8E(i interface{}) (int8, error) {
 	i = indirect(i)
@@ -471,6 +627,58 @@ func ToInt8E(i interface{}) (int8, error) {
 	}
 }
 
+// ToInt8EB casts an interface to an int8 type.
+func ToInt8EB(i interface{}, b int) (int8, error) {
+	i = indirect(i)
+
+	intv, ok := toInt(i)
+	if ok {
+		return int8(intv), nil
+	}
+
+	switch s := i.(type) {
+	case int64:
+		return int8(s), nil
+	case int32:
+		return int8(s), nil
+	case int16:
+		return int8(s), nil
+	case int8:
+		return s, nil
+	case uint:
+		return int8(s), nil
+	case uint64:
+		return int8(s), nil
+	case uint32:
+		return int8(s), nil
+	case uint16:
+		return int8(s), nil
+	case uint8:
+		return int8(s), nil
+	case float64:
+		return int8(s), nil
+	case float32:
+		return int8(s), nil
+	case string:
+		v, err := strconv.ParseInt(trimZeroDecimal(s), b, 0)
+		if err == nil {
+			return int8(v), nil
+		}
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to int8", i, i, b)
+	case json.Number:
+		return ToInt8EB(string(s), b)
+	case bool:
+		if s {
+			return 1, nil
+		}
+		return 0, nil
+	case nil:
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to int8", i, i, b)
+	}
+}
+
 // ToIntE casts an interface to an int type.
 func ToIntE(i interface{}) (int, error) {
 	i = indirect(i)
@@ -520,6 +728,58 @@ func ToIntE(i interface{}) (int, error) {
 		return 0, nil
 	default:
 		return 0, fmt.Errorf("unable to cast %#v of type %T to int", i, i)
+	}
+}
+
+// ToIntEB casts an interface to an int type.
+func ToIntEB(i interface{}, b int) (int, error) {
+	i = indirect(i)
+
+	intv, ok := toInt(i)
+	if ok {
+		return intv, nil
+	}
+
+	switch s := i.(type) {
+	case int64:
+		return int(s), nil
+	case int32:
+		return int(s), nil
+	case int16:
+		return int(s), nil
+	case int8:
+		return int(s), nil
+	case uint:
+		return int(s), nil
+	case uint64:
+		return int(s), nil
+	case uint32:
+		return int(s), nil
+	case uint16:
+		return int(s), nil
+	case uint8:
+		return int(s), nil
+	case float64:
+		return int(s), nil
+	case float32:
+		return int(s), nil
+	case string:
+		v, err := strconv.ParseInt(trimZeroDecimal(s), b, 0)
+		if err == nil {
+			return int(v), nil
+		}
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to int64", i, i, b)
+	case json.Number:
+		return ToIntEB(string(s), b)
+	case bool:
+		if s {
+			return 1, nil
+		}
+		return 0, nil
+	case nil:
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to int", i, i, b)
 	}
 }
 
@@ -599,6 +859,82 @@ func ToUintE(i interface{}) (uint, error) {
 	}
 }
 
+// ToUintEB casts an interface to a uint type.
+func ToUintEB(i interface{}, b int) (uint, error) {
+	i = indirect(i)
+
+	intv, ok := toInt(i)
+	if ok {
+		if intv < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint(intv), nil
+	}
+
+	switch s := i.(type) {
+	case string:
+		v, err := strconv.ParseInt(trimZeroDecimal(s), b, 0)
+		if err == nil {
+			if v < 0 {
+				return 0, errNegativeNotAllowed
+			}
+			return uint(v), nil
+		}
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to uint", i, i, b)
+	case json.Number:
+		return ToUintEB(string(s), b)
+	case int64:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint(s), nil
+	case int32:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint(s), nil
+	case int16:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint(s), nil
+	case int8:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint(s), nil
+	case uint:
+		return s, nil
+	case uint64:
+		return uint(s), nil
+	case uint32:
+		return uint(s), nil
+	case uint16:
+		return uint(s), nil
+	case uint8:
+		return uint(s), nil
+	case float64:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint(s), nil
+	case float32:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint(s), nil
+	case bool:
+		if s {
+			return 1, nil
+		}
+		return 0, nil
+	case nil:
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to uint", i, i, b)
+	}
+}
+
 // ToUint64E casts an interface to a uint64 type.
 func ToUint64E(i interface{}) (uint64, error) {
 	i = indirect(i)
@@ -620,6 +956,79 @@ func ToUint64E(i interface{}) (uint64, error) {
 		return 0, fmt.Errorf("unable to cast %#v of type %T to uint64", i, i)
 	case json.Number:
 		return ToUint64E(string(s))
+	case int64:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint64(s), nil
+	case int32:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint64(s), nil
+	case int16:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint64(s), nil
+	case int8:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint64(s), nil
+	case uint:
+		return uint64(s), nil
+	case uint64:
+		return s, nil
+	case uint32:
+		return uint64(s), nil
+	case uint16:
+		return uint64(s), nil
+	case uint8:
+		return uint64(s), nil
+	case float32:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint64(s), nil
+	case float64:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint64(s), nil
+	case bool:
+		if s {
+			return 1, nil
+		}
+		return 0, nil
+	case nil:
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("unable to cast %#v of type %T to uint64", i, i)
+	}
+}
+
+// ToUint64EB casts an interface to a uint64 type.
+func ToUint64EB(i interface{}, b int) (uint64, error) {
+	i = indirect(i)
+
+	intv, ok := toInt(i)
+	if ok {
+		if intv < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint64(intv), nil
+	}
+
+	switch s := i.(type) {
+	case string:
+		v, err := strconv.ParseUint(trimZeroDecimal(s), b, 0)
+		if err == nil {
+			return v, nil
+		}
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to uint64", i, i, b)
+	case json.Number:
+		return ToUint64EB(string(s), b)
 	case int64:
 		if s < 0 {
 			return 0, errNegativeNotAllowed
@@ -748,6 +1157,82 @@ func ToUint32E(i interface{}) (uint32, error) {
 	}
 }
 
+// ToUint32EB casts an interface to a uint32 type.
+func ToUint32EB(i interface{}, b int) (uint32, error) {
+	i = indirect(i)
+
+	intv, ok := toInt(i)
+	if ok {
+		if intv < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint32(intv), nil
+	}
+
+	switch s := i.(type) {
+	case string:
+		v, err := strconv.ParseInt(trimZeroDecimal(s), b, 0)
+		if err == nil {
+			if v < 0 {
+				return 0, errNegativeNotAllowed
+			}
+			return uint32(v), nil
+		}
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to uint32", i, i, b)
+	case json.Number:
+		return ToUint32EB(string(s), b)
+	case int64:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint32(s), nil
+	case int32:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint32(s), nil
+	case int16:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint32(s), nil
+	case int8:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint32(s), nil
+	case uint:
+		return uint32(s), nil
+	case uint64:
+		return uint32(s), nil
+	case uint32:
+		return s, nil
+	case uint16:
+		return uint32(s), nil
+	case uint8:
+		return uint32(s), nil
+	case float64:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint32(s), nil
+	case float32:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint32(s), nil
+	case bool:
+		if s {
+			return 1, nil
+		}
+		return 0, nil
+	case nil:
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("unable to cast %#v of type %T (base %d) to uint32", i, i, b)
+	}
+}
+
 // ToUint16E casts an interface to a uint16 type.
 func ToUint16E(i interface{}) (uint16, error) {
 	i = indirect(i)
@@ -824,6 +1309,82 @@ func ToUint16E(i interface{}) (uint16, error) {
 	}
 }
 
+// ToUint16EB casts an interface to a uint16 type.
+func ToUint16EB(i interface{}, b int) (uint16, error) {
+	i = indirect(i)
+
+	intv, ok := toInt(i)
+	if ok {
+		if intv < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint16(intv), nil
+	}
+
+	switch s := i.(type) {
+	case string:
+		v, err := strconv.ParseInt(trimZeroDecimal(s), b, 0)
+		if err == nil {
+			if v < 0 {
+				return 0, errNegativeNotAllowed
+			}
+			return uint16(v), nil
+		}
+		return 0, fmt.Errorf("unable to cast %#v of type %T to uint16", i, i)
+	case json.Number:
+		return ToUint16EB(string(s), b)
+	case int64:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint16(s), nil
+	case int32:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint16(s), nil
+	case int16:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint16(s), nil
+	case int8:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint16(s), nil
+	case uint:
+		return uint16(s), nil
+	case uint64:
+		return uint16(s), nil
+	case uint32:
+		return uint16(s), nil
+	case uint16:
+		return s, nil
+	case uint8:
+		return uint16(s), nil
+	case float64:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint16(s), nil
+	case float32:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint16(s), nil
+	case bool:
+		if s {
+			return 1, nil
+		}
+		return 0, nil
+	case nil:
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("unable to cast %#v of type %T to uint16", i, i)
+	}
+}
+
 // ToUint8E casts an interface to a uint type.
 func ToUint8E(i interface{}) (uint8, error) {
 	i = indirect(i)
@@ -848,6 +1409,82 @@ func ToUint8E(i interface{}) (uint8, error) {
 		return 0, fmt.Errorf("unable to cast %#v of type %T to uint8", i, i)
 	case json.Number:
 		return ToUint8E(string(s))
+	case int64:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint8(s), nil
+	case int32:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint8(s), nil
+	case int16:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint8(s), nil
+	case int8:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint8(s), nil
+	case uint:
+		return uint8(s), nil
+	case uint64:
+		return uint8(s), nil
+	case uint32:
+		return uint8(s), nil
+	case uint16:
+		return uint8(s), nil
+	case uint8:
+		return s, nil
+	case float64:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint8(s), nil
+	case float32:
+		if s < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint8(s), nil
+	case bool:
+		if s {
+			return 1, nil
+		}
+		return 0, nil
+	case nil:
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("unable to cast %#v of type %T to uint8", i, i)
+	}
+}
+
+// ToUint8EB casts an interface to a uint type.
+func ToUint8EB(i interface{}, b int) (uint8, error) {
+	i = indirect(i)
+
+	intv, ok := toInt(i)
+	if ok {
+		if intv < 0 {
+			return 0, errNegativeNotAllowed
+		}
+		return uint8(intv), nil
+	}
+
+	switch s := i.(type) {
+	case string:
+		v, err := strconv.ParseInt(trimZeroDecimal(s), b, 0)
+		if err == nil {
+			if v < 0 {
+				return 0, errNegativeNotAllowed
+			}
+			return uint8(v), nil
+		}
+		return 0, fmt.Errorf("unable to cast %#v of type %T to uint8", i, i)
+	case json.Number:
+		return ToUint8EB(string(s), b)
 	case int64:
 		if s < 0 {
 			return 0, errNegativeNotAllowed


### PR DESCRIPTION
This PR fixes #232 by allowing the user to cast as a Base derived value from the interface. 

Methods added:

```
# Public Methods inside `cast.go`
ToBaseInt64(input interface, base int)
ToBaseInt32(input interface, base int)
ToBaseInt16(input interface, base int)
ToBaseInt8(input interface, base int)
ToBaseInt(input interface, base int)
ToBaseUint(input interface, base int)
ToBaseUint64(input interface, base int)
ToBaseUint32(input interface, base int)
ToBaseUint16(input interface, base int)
ToBaseUint8(input interface, base int)

# Internal Methods inside `caste.go`
ToUint8EB(input interface, base int)
ToUint16EB(input interface, base int)
ToUint32EB(input interface, base int)
ToUint64EB(input interface, base int)
ToUintEB(input interface, base int)
ToIntEB(input interface, base int)
ToInt8EB(input interface, base int)
ToInt16EB(input interface, base int)
ToInt32EB(input interface, base int)
ToInt64EB(input interface, base int)
```

Quite literally, this PR duplicates a TON of code (lovely) and provides you the ability to specify the 2nd argument on the `strconv.Parse<Int|Uint>(num, base, bits)` functions in `caste.go`. 