### PR TITLE
refactor: go1.21.0 messup dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spf13/cast
 
-go 1.21.0
+go 1.21
 
 require github.com/frankban/quicktest v1.14.6
 


### PR DESCRIPTION
minor declare cause problem when user `go mod tidy`;
it will downgrade or change user's  toolchain instruction and mess up  dependencies