### PR TITLE
Add support for JSON to slice cast

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -6,6 +6,7 @@
 package cast
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -90,8 +91,15 @@ func ToStringSliceE(i any) ([]string, error) {
 
 	var a []string
 
+	if nonPointerI, ok := indirect(i); ok {
+		i = nonPointerI
+	}
+
 	switch v := i.(type) {
 	case string:
+		if err := json.Unmarshal([]byte(v), &a); err == nil {
+			return a, nil
+		}
 		return strings.Fields(v), nil
 	case any:
 		str, err := ToStringE(v)

--- a/slice_test.go
+++ b/slice_test.go
@@ -258,6 +258,8 @@ func TestStringSlice(t *testing.T) {
 		{[]any{1, 3}, []string{"1", "3"}, false},
 		{any(1), []string{"1"}, false},
 		{[]error{errors.New("a"), errors.New("b")}, []string{"a", "b"}, false},
+		{"[\"a\", \"b\"]", []string{"a", "b"}, false},
+		{"a b", []string{"a", "b"}, false},
 
 		// Failure cases
 		{nil, nil, true},


### PR DESCRIPTION
This adds support for JSON array in `ToStringSliceE` in the same way that JSON is supported when using `toMapE`.