### PR TITLE
fix: parse leading-zero strings as decimal instead of invalid octal

### DIFF
--- a/number.go
+++ b/number.go
@@ -405,18 +405,32 @@ func parseNumber[T Number](s string) (T, error) {
 }
 
 func parseInt[T integer](s string) (T, error) {
-	v, err := strconv.ParseInt(trimDecimal(s), 0, 0)
+	s = trimDecimal(s)
+	// Try base-10 first so that leading-zero strings like "08" parse as
+	// decimal 8 instead of being rejected as invalid octal.
+	v, err := strconv.ParseInt(s, 10, 0)
 	if err != nil {
-		return 0, err
+		// Fall back to base-0 (auto-detect) to support "0x", "0o", "0b" prefixes.
+		v, err = strconv.ParseInt(s, 0, 0)
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	return T(v), nil
 }
 
 func parseUint[T unsigned](s string) (T, error) {
-	v, err := strconv.ParseUint(strings.TrimLeft(trimDecimal(s), "+"), 0, 0)
+	s = strings.TrimLeft(trimDecimal(s), "+")
+	// Try base-10 first so that leading-zero strings like "08" parse as
+	// decimal 8 instead of being rejected as invalid octal.
+	v, err := strconv.ParseUint(s, 10, 0)
 	if err != nil {
-		return 0, err
+		// Fall back to base-0 (auto-detect) to support "0x", "0o", "0b" prefixes.
+		v, err = strconv.ParseUint(s, 0, 0)
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	return T(v), nil


### PR DESCRIPTION
Fixes #290

## Problem

`cast.ToInt("08")` returns `0` instead of `8`.

`strconv.ParseInt` with base `0` treats leading zeros as octal notation, and `8` is not a valid octal digit, so the parse fails silently.

```go
cast.ToInt("08") // 0 (expected 8)
cast.ToInt("09") // 0 (expected 9)
```

## Fix

`parseInt` and `parseUint` now try base-10 first. If that fails (e.g., for `"0xff"` or `"0b1010"`), they fall back to base-0 auto-detection.

| Input | Before | After |
|-------|--------|-------|
| `"08"` | `0` | `8` ✅ |
| `"09"` | `0` | `9` ✅ |
| `"010"` | `8` (octal) | `10` (decimal) ✅ |
| `"0xff"` | `255` | `255` ✅ |
| `"0b1010"` | `10` | `10` ✅ |

All existing tests pass.