### PR TITLE
Fix incorrect comment for ToUint8E

### DIFF
--- a/number.go
+++ b/number.go
@@ -499,7 +499,7 @@ func ToUint16E(i any) (uint16, error) {
 	return toUnsignedNumberE[uint16](i, parseUint[uint16])
 }
 
-// ToUint8E casts an interface to a uint type.
+// ToUint8E casts an interface to a uint8 type.
 func ToUint8E(i any) (uint8, error) {
 	return toUnsignedNumberE[uint8](i, parseUint[uint8])
 }


### PR DESCRIPTION
## Summary

Fix a copy-paste error in the godoc comment for `ToUint8E`:

- Before: `// ToUint8E casts an interface to a uint type.`
- After: `// ToUint8E casts an interface to a uint8 type.`

All sibling functions (`ToUint16E`, `ToUint32E`, `ToUint64E`) already have correct type-specific comments.