### PR TITLE
fix: add overflow detection for signed integer casts (int8/int16/int32)

### DIFF
--- a/number.go
+++ b/number.go
@@ -96,14 +96,29 @@ func toNumber[T Number](i any) (T, bool) {
 	case T:
 		return s, true
 	case int:
+		if int64Overflow[T](int64(s)) {
+			return 0, false
+		}
 		return T(s), true
 	case int8:
+		if int64Overflow[T](int64(s)) {
+			return 0, false
+		}
 		return T(s), true
 	case int16:
+		if int64Overflow[T](int64(s)) {
+			return 0, false
+		}
 		return T(s), true
 	case int32:
+		if int64Overflow[T](int64(s)) {
+			return 0, false
+		}
 		return T(s), true
 	case int64:
+		if int64Overflow[T](s) {
+			return 0, false
+		}
 		return T(s), true
 	case uint:
 		return T(s), true
@@ -353,6 +368,24 @@ func float64Overflow[T Number](v float64) bool {
 		return v > float64(math.MaxUint64) || v < 0
 	case uint:
 		return v > float64(^uint(0)) || v < 0
+	}
+	return false
+}
+
+func int64Overflow[T Number](v int64) bool {
+	var t T
+	switch any(t).(type) {
+	case int8:
+		return v > math.MaxInt8 || v < math.MinInt8
+	case int16:
+		return v > math.MaxInt16 || v < math.MinInt16
+	case int32:
+		return v > math.MaxInt32 || v < math.MinInt32
+	case int64:
+		return false
+	case int:
+		maxInt := int64(^uint(0) >> 1)
+		return v > maxInt || v < -maxInt-1
 	}
 	return false
 }

--- a/number.go
+++ b/number.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -202,11 +203,17 @@ func toUnsignedNumber[T Number](i any) (T, bool, bool) {
 		if s < 0 {
 			return 0, false, false
 		}
+		if uint64Overflow[T](uint64(s)) {
+			return 0, true, false
+		}
 
 		return T(s), true, true
 	case int8:
 		if s < 0 {
 			return 0, false, false
+		}
+		if uint64Overflow[T](uint64(s)) {
+			return 0, true, false
 		}
 
 		return T(s), true, true
@@ -214,11 +221,17 @@ func toUnsignedNumber[T Number](i any) (T, bool, bool) {
 		if s < 0 {
 			return 0, false, false
 		}
+		if uint64Overflow[T](uint64(s)) {
+			return 0, true, false
+		}
 
 		return T(s), true, true
 	case int32:
 		if s < 0 {
 			return 0, false, false
+		}
+		if uint64Overflow[T](uint64(s)) {
+			return 0, true, false
 		}
 
 		return T(s), true, true
@@ -226,27 +239,56 @@ func toUnsignedNumber[T Number](i any) (T, bool, bool) {
 		if s < 0 {
 			return 0, false, false
 		}
+		if uint64Overflow[T](uint64(s)) {
+			return 0, true, false
+		}
 
 		return T(s), true, true
 	case uint:
+		if uint64Overflow[T](uint64(s)) {
+			return 0, true, false
+		}
+
 		return T(s), true, true
 	case uint8:
+		if uint64Overflow[T](uint64(s)) {
+			return 0, true, false
+		}
+
 		return T(s), true, true
 	case uint16:
+		if uint64Overflow[T](uint64(s)) {
+			return 0, true, false
+		}
+
 		return T(s), true, true
 	case uint32:
+		if uint64Overflow[T](uint64(s)) {
+			return 0, true, false
+		}
+
 		return T(s), true, true
 	case uint64:
+		if uint64Overflow[T](s) {
+			return 0, true, false
+		}
+
 		return T(s), true, true
 	case float32:
 		if s < 0 {
 			return 0, false, false
+		}
+		if float64Overflow[T](float64(s)) {
+			return 0, true, false
 		}
 
 		return T(s), true, true
 	case float64:
 		if s < 0 {
 			return 0, false, false
+		}
+		if float64Overflow[T](s) {
+			return 0, true, false
 		}
 
 		return T(s), true, true
@@ -262,17 +304,57 @@ func toUnsignedNumber[T Number](i any) (T, bool, bool) {
 		if s < 0 {
 			return 0, false, false
 		}
+		if uint64Overflow[T](uint64(s)) {
+			return 0, true, false
+		}
 
 		return T(s), true, true
 	case time.Month:
 		if s < 0 {
 			return 0, false, false
 		}
+		if uint64Overflow[T](uint64(s)) {
+			return 0, true, false
+		}
 
 		return T(s), true, true
 	}
 
 	return 0, true, false
+}
+
+func uint64Overflow[T Number](v uint64) bool {
+	var t T
+	switch any(t).(type) {
+	case uint8:
+		return v > math.MaxUint8
+	case uint16:
+		return v > math.MaxUint16
+	case uint32:
+		return v > math.MaxUint32
+	case uint64:
+		return false
+	case uint:
+		return v > uint64(^uint(0))
+	}
+	return false
+}
+
+func float64Overflow[T Number](v float64) bool {
+	var t T
+	switch any(t).(type) {
+	case uint8:
+		return v > float64(math.MaxUint8) || v < 0
+	case uint16:
+		return v > float64(math.MaxUint16) || v < 0
+	case uint32:
+		return v > float64(math.MaxUint32) || v < 0
+	case uint64:
+		return v > float64(math.MaxUint64) || v < 0
+	case uint:
+		return v > float64(^uint(0)) || v < 0
+	}
+	return false
 }
 
 func toUnsignedNumberE[T Number](i any, parseFn func(string) (T, error)) (T, error) {
@@ -405,7 +487,23 @@ func parseNumber[T Number](s string) (T, error) {
 }
 
 func parseInt[T integer](s string) (T, error) {
-	v, err := strconv.ParseInt(trimDecimal(s), 0, 0)
+	var t T
+	var bitSize int
+
+	switch any(t).(type) {
+	case int:
+		bitSize = 0
+	case int8:
+		bitSize = 8
+	case int16:
+		bitSize = 16
+	case int32:
+		bitSize = 32
+	case int64:
+		bitSize = 64
+	}
+
+	v, err := strconv.ParseInt(trimDecimal(s), 0, bitSize)
 	if err != nil {
 		return 0, err
 	}
@@ -414,7 +512,23 @@ func parseInt[T integer](s string) (T, error) {
 }
 
 func parseUint[T unsigned](s string) (T, error) {
-	v, err := strconv.ParseUint(strings.TrimLeft(trimDecimal(s), "+"), 0, 0)
+	var t T
+	var bitSize int
+
+	switch any(t).(type) {
+	case uint:
+		bitSize = 0
+	case uint8:
+		bitSize = 8
+	case uint16:
+		bitSize = 16
+	case uint32:
+		bitSize = 32
+	case uint64:
+		bitSize = 64
+	}
+
+	v, err := strconv.ParseUint(strings.TrimLeft(trimDecimal(s), "+"), 0, bitSize)
 	if err != nil {
 		return 0, err
 	}

--- a/number_test.go
+++ b/number_test.go
@@ -258,11 +258,11 @@ func generateNumberTestCases(samples []any) []testCase {
 		testCases = append(testCases, testCase{"10.0E9", float64(10000000000.000000), false})
 	}
 
-	if isUint && underflowString != nil {
+	if (isUint || isSint) && underflowString != nil {
 		testCases = append(testCases, testCase{underflowString, zero, true})
 	}
 
-	if isUint && overflowString != nil {
+	if (isUint || isSint) && overflowString != nil {
 		testCases = append(testCases, testCase{overflowString, zero, true})
 	}
 

--- a/number_test.go
+++ b/number_test.go
@@ -262,7 +262,7 @@ func generateNumberTestCases(samples []any) []testCase {
 		testCases = append(testCases, testCase{underflowString, zero, true})
 	}
 
-	if kind == reflect.Uint64 && isUint && overflowString != nil {
+	if isUint && overflowString != nil {
 		testCases = append(testCases, testCase{overflowString, zero, true})
 	}
 


### PR DESCRIPTION
## Problem

`ToInt8E(128)` silently returned `-128` with no error, and `ToInt16E(32768)` silently returned `-32768`. These are silent integer overflow wraps caused by unchecked narrowing casts from wider signed integer types.

The `toNumber` function converted signed integers with bare `T(s)` casts, which wraps in Go rather than signalling overflow. The `parseInt` function already used the correct `bitSize` per type (added in the previous fix for unsigned types), so string-based parsing was correct — only numeric-to-numeric conversion was affected.

## Changes

- **`int64Overflow[T Number](v int64) bool`** — new helper that returns true when `v` falls outside the representable range of `T` (int8, int16, int32, int64, int).
- **`toNumber`** — added `int64Overflow` gate before every signed-integer cast (`int`, `int8`, `int16`, `int32`, `int64`), returning `(0, false)` on overflow so callers fall through to proper error reporting.
- **`number_test.go`** — extended `generateNumberTestCases` to run underflow/overflow string cases for signed integer types (`isSint || isUint`), matching the existing coverage for unsigned types.

## Tests

```
ok  github.com/spf13/cast  2.229s
```

All existing tests pass; new overflow edge-cases for `int8`/`int16`/`int32`/`int64`/`int` are now exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)