### PR TITLE
fix: avoid panic when ToStringE receives nil Stringer pointer

### DIFF
--- a/basic.go
+++ b/basic.go
@@ -114,6 +114,9 @@ func ToStringE(i any) (string, error) {
 	case nil:
 		return "", nil
 	case fmt.Stringer:
+		if stringerIsNil(s) {
+			return "", nil
+		}
 		return s.String(), nil
 	case error:
 		return s.Error(), nil

--- a/basic_test.go
+++ b/basic_test.go
@@ -107,6 +107,7 @@ func TestString(t *testing.T) {
 	key := &Key{"foo"}
 
 	var ptr *string
+	var nilTime *time.Time
 
 	testCases := []testCase{
 		{int(8), "8", false},
@@ -126,6 +127,7 @@ func TestString(t *testing.T) {
 		{false, "false", false},
 		{nil, "", false},
 		{ptr, "", false},
+		{nilTime, "", false},
 		{[]byte("one time"), "one time", false},
 		{"one more time", "one more time", false},
 		{template.HTML("one time"), "one time", false},

--- a/indirect.go
+++ b/indirect.go
@@ -6,6 +6,7 @@
 package cast
 
 import (
+	"fmt"
 	"reflect"
 )
 
@@ -34,4 +35,18 @@ func indirect(i any) (any, bool) {
 	}
 
 	return v.Interface(), true
+}
+
+func stringerIsNil(s fmt.Stringer) bool {
+	if s == nil {
+		return true
+	}
+
+	v := reflect.ValueOf(s)
+	switch v.Kind() {
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
## Summary

- Fixes a panic when `ToStringE` is called with a nil pointer whose type implements `fmt.Stringer` (reported for `*time.Time` in #227)
- Guard the `fmt.Stringer` branch so nil pointer/interface receivers return `""` instead of calling `String()` on a nil receiver

## Test plan

- [x] Added `nil *time.Time` case to `TestString`
- [x] `go test ./...`
- [x] Manual repro: `cast.ToStringE((*time.Time)(nil))` returns `""` without panic

Fixes #227