### PR TITLE
number: derive ParseInt/ParseUint bitSize from the target type

### DIFF
--- a/number.go
+++ b/number.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unsafe"
 )
 
 var errNegativeNotAllowed = errors.New("unable to cast negative value")
@@ -405,7 +406,8 @@ func parseNumber[T Number](s string) (T, error) {
 }
 
 func parseInt[T integer](s string) (T, error) {
-	v, err := strconv.ParseInt(trimDecimal(s), 0, 0)
+	var t T
+	v, err := strconv.ParseInt(trimDecimal(s), 0, int(unsafe.Sizeof(t))*8)
 	if err != nil {
 		return 0, err
 	}
@@ -414,7 +416,8 @@ func parseInt[T integer](s string) (T, error) {
 }
 
 func parseUint[T unsigned](s string) (T, error) {
-	v, err := strconv.ParseUint(strings.TrimLeft(trimDecimal(s), "+"), 0, 0)
+	var t T
+	v, err := strconv.ParseUint(strings.TrimLeft(trimDecimal(s), "+"), 0, int(unsafe.Sizeof(t))*8)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
\`parseInt\`/\`parseUint\` passed \`bitSize=0\` to \`strconv\`, which means native int width. On a 32-bit platform that's 32 even when \`T\` is \`int64\`, so strings like \`\"9223372036854775807\"\` or \`\"18446744073709551615\"\` fail to round-trip through cast. That's the armhf \`TestNumber\` failure from the issue.

Switched to \`unsafe.Sizeof(t)*8\`, which matches \`T\`'s actual width at each generic instantiation (8/16/32/64 for the fixed-size variants, \`strconv.IntSize\` for \`int\`/\`uint\`). Overflow detection for the smaller types is preserved, and the \`cast.go\` call sites that pass \`parseInt[T]\` as a function reference don't change.

fixes #310