### PR TITLE
docs: fix ToTimeE and ToUint8E godoc accuracy

### DIFF
--- a/number.go
+++ b/number.go
@@ -499,7 +499,7 @@ func ToUint16E(i any) (uint16, error) {
 	return toUnsignedNumberE[uint16](i, parseUint[uint16])
 }
 
-// ToUint8E casts an interface to a uint type.
+// ToUint8E casts an interface to a uint8 type.
 func ToUint8E(i any) (uint8, error) {
 	return toUnsignedNumberE[uint8](i, parseUint[uint8])
 }

--- a/time.go
+++ b/time.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cast/internal"
 )
 
-// ToTimeE any value to a [time.Time] type.
+// ToTimeE casts any value to a [time.Time] type.
 func ToTimeE(i any) (time.Time, error) {
 	return ToTimeInDefaultLocationE(i, time.UTC)
 }


### PR DESCRIPTION
## Summary
- \`ToTimeE\`: godoc was missing the verb (\"any value to…\" → \"casts any value to…\").
- \`ToUint8E\`: comment incorrectly said \"uint\" instead of \"uint8\".

## Test plan
- docs only