### PR TITLE
fix: parse Unix timestamps from numeric strings and floats in ToTimeE

### DIFF
--- a/time.go
+++ b/time.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,6 +31,23 @@ func ToTimeInDefaultLocationE(i any, location *time.Location) (tim time.Time, er
 	case time.Time:
 		return v, nil
 	case string:
+		// Prefer named date formats; fall back to Unix seconds for numeric strings.
+		// Require 10+ digits so short values like "2006" stay date formats, not seconds.
+		if tm, err := StringToDateInDefaultLocation(v, location); err == nil {
+			return tm, nil
+		}
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			if len(v) >= 10 || n <= -1_000_000_000 {
+				return time.Unix(n, 0), nil
+			}
+		}
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			sec := int64(f)
+			if absInt64(sec) >= 1_000_000_000 {
+				nsec := int64((f - float64(sec)) * 1e9)
+				return time.Unix(sec, nsec), nil
+			}
+		}
 		return StringToDateInDefaultLocation(v, location)
 	case json.Number:
 		// Originally this used ToInt64E, but adding string float conversion broke ToTime.
@@ -53,6 +71,12 @@ func ToTimeInDefaultLocationE(i any, location *time.Location) (tim time.Time, er
 		return time.Unix(int64(v), 0), nil
 	case uint64:
 		return time.Unix(int64(v), 0), nil
+	case float32:
+		return time.Unix(int64(v), 0), nil
+	case float64:
+		sec := int64(v)
+		nsec := int64((v - float64(sec)) * 1e9)
+		return time.Unix(sec, nsec), nil
 	case nil:
 		return time.Time{}, nil
 	default:
@@ -113,4 +137,11 @@ func StringToDate(s string) (time.Time, error) {
 // or the local timezone if nil.
 func StringToDateInDefaultLocation(s string, location *time.Location) (time.Time, error) {
 	return internal.ParseDateWith(s, location, internal.TimeFormats)
+}
+
+func absInt64(n int64) int64 {
+	if n < 0 {
+		return -n
+	}
+	return n
 }

--- a/time_unix_test.go
+++ b/time_unix_test.go
@@ -1,0 +1,35 @@
+package cast
+
+import (
+	"testing"
+	"time"
+)
+
+func TestToTimeUnixNumericString(t *testing.T) {
+	const sec int64 = 1609459200 // 2021-01-01T00:00:00Z
+	want := time.Unix(sec, 0).UTC()
+
+	got, err := ToTimeE("1609459200")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.UTC().Equal(want) {
+		t.Fatalf("string unix: got %v want %v", got.UTC(), want)
+	}
+
+	got, err = ToTimeE(float64(sec) + 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Unix() != sec {
+		t.Fatalf("float unix sec: got %d", got.Unix())
+	}
+	// named formats still work
+	got, err = ToTimeE("2021-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.UTC().Format(time.RFC3339) != "2021-01-01T00:00:00Z" {
+		t.Fatalf("rfc3339: got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
`ToTimeE(int64(1609459200))` works, but `ToTimeE("1609459200")` and `ToTimeE(float64(...))` failed.

After normal date formats, treat long pure-numeric strings (10+ digits) and large float values as Unix seconds. Short numbers like `"2006"` still go through year/date parsing only.

## Test plan
- [x] `go test ./...`
- [x] New cases for string/float Unix timestamps + RFC3339 still works