### PR TITLE
fix: trim surrounding spaces in string numeric casts

### DIFF
--- a/basic.go
+++ b/basic.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"html/template"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -49,7 +50,7 @@ func ToBoolE(i any) (bool, error) {
 	case time.Duration:
 		return b != 0, nil
 	case string:
-		return strconv.ParseBool(b)
+		return strconv.ParseBool(strings.TrimSpace(b))
 	case json.Number:
 		v, err := ToInt64E(b)
 		if err == nil {

--- a/basic_test.go
+++ b/basic_test.go
@@ -164,3 +164,12 @@ type fu struct {
 func (x fu) Error() string {
 	return x.val
 }
+
+func TestToBoolTrimSpace(t *testing.T) {
+	if v, err := cast.ToBoolE(" true "); err != nil || !v {
+		t.Fatalf("ToBoolE spaces: %v %v", v, err)
+	}
+	if v, err := cast.ToBoolE(" false "); err != nil || v {
+		t.Fatalf("ToBoolE false spaces: %v %v", v, err)
+	}
+}

--- a/number.go
+++ b/number.go
@@ -145,6 +145,7 @@ func toNumberE[T Number](i any, parseFn func(string) (T, error)) (T, error) {
 
 	switch s := i.(type) {
 	case string:
+		s = strings.TrimSpace(s)
 		if s == "" {
 			return 0, nil
 		}
@@ -289,6 +290,7 @@ func toUnsignedNumberE[T Number](i any, parseFn func(string) (T, error)) (T, err
 
 	switch s := i.(type) {
 	case string:
+		s = strings.TrimSpace(s)
 		if s == "" {
 			return 0, nil
 		}

--- a/number_test.go
+++ b/number_test.go
@@ -464,3 +464,15 @@ func BenchmarkNumber(b *testing.B) {
 		})
 	}
 }
+
+func TestToNumberTrimSpace(t *testing.T) {
+	if v, err := cast.ToIntE(" 42 "); err != nil || v != 42 {
+		t.Fatalf("ToIntE spaces: %v %v", v, err)
+	}
+	if v, err := cast.ToFloat64E(" 3.5 "); err != nil || v != 3.5 {
+		t.Fatalf("ToFloat64E spaces: %v %v", v, err)
+	}
+	if v, err := cast.ToUintE(" 7 "); err != nil || v != 7 {
+		t.Fatalf("ToUintE spaces: %v %v", v, err)
+	}
+}

--- a/time.go
+++ b/time.go
@@ -84,6 +84,10 @@ func ToDurationE(i any) (time.Duration, error) {
 
 		return time.Duration(v), nil
 	case string:
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return 0, nil
+		}
 		if !strings.ContainsAny(s, "nsuµmh") {
 			return time.ParseDuration(s + "ns")
 		}

--- a/time_test.go
+++ b/time_test.go
@@ -290,3 +290,9 @@ func locationEqual(a, b *time.Location) bool {
 
 	return tA.Equal(tB)
 }
+
+func TestToDurationTrimSpace(t *testing.T) {
+	if v, err := cast.ToDurationE(" 1s "); err != nil || v != time.Second {
+		t.Fatalf("ToDurationE spaces: %v %v", v, err)
+	}
+}


### PR DESCRIPTION
## Summary

String inputs like `" 42 "` / `" 1s "` / `" true "` failed `ToIntE` / `ToDurationE` / `ToBoolE` because strconv does not trim.

Trim surrounding spaces before parsing in the shared number path, bool, and duration casts.

## Test plan

- [x] `go test -run 'TestToNumberTrimSpace|TestToBoolTrimSpace|TestToDurationTrimSpace'`
- [x] full package tests