### PR TITLE
feat: accept bare hex strings in ToUint64

### DIFF
--- a/number.go
+++ b/number.go
@@ -414,12 +414,44 @@ func parseInt[T integer](s string) (T, error) {
 }
 
 func parseUint[T unsigned](s string) (T, error) {
-	v, err := strconv.ParseUint(strings.TrimLeft(trimDecimal(s), "+"), 0, 0)
+	s = strings.TrimLeft(trimDecimal(s), "+")
+	v, err := strconv.ParseUint(s, 0, 0)
 	if err != nil {
+		// Accept bare hex (no 0x prefix), e.g. "882d5422d5fffff" (#334).
+		if isHexString(s) {
+			if hv, herr := strconv.ParseUint(s, 16, 0); herr == nil {
+				return T(hv), nil
+			}
+		}
 		return 0, err
 	}
 
 	return T(v), nil
+}
+
+func isHexString(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= '0' && c <= '9', c >= 'a' && c <= 'f', c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+	// Require at least one a-f so pure decimals stay base-10 via ParseUint base 0.
+	// Bare hex without letters is ambiguous with decimal; callers can use 0x.
+	hasLetter := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') {
+			hasLetter = true
+			break
+		}
+	}
+	return hasLetter
 }
 
 func parseFloat[T float](s string) (T, error) {

--- a/number_test.go
+++ b/number_test.go
@@ -464,3 +464,16 @@ func BenchmarkNumber(b *testing.B) {
 		})
 	}
 }
+
+func TestToUint64HexString(t *testing.T) {
+	// #334: bare hex strings should cast to uint64.
+	c := qt.New(t)
+	got, err := cast.ToUint64E("882d5422d5fffff")
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.Equals, uint64(0x882d5422d5fffff))
+	c.Assert(cast.ToUint64("882d5422d5fffff"), qt.Equals, uint64(0x882d5422d5fffff))
+	// 0x prefix still works
+	got, err = cast.ToUint64E("0x10")
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.Equals, uint64(16))
+}


### PR DESCRIPTION
## Summary

`strconv.ParseUint` with base `0` only treats hex with a `0x`/`0X` prefix. Bare hex like `882d5422d5fffff` failed to cast (#334).

## Fix

If base-0 parse fails and the string is hex digits with at least one `a-f` letter, retry base 16.

## Tests

```text
go test . -count=1 -run TestToUint64HexString
# ok
```

Fixes #334