### PR TITLE
bench: add IntSlice and Duration benchmarks to BenchmarkCast

### DIFF
--- a/cast_test.go
+++ b/cast_test.go
@@ -222,6 +222,18 @@ func BenchmarkCast(b *testing.B) {
 			cast.ToStringSlice([]int{123456789, 123456789, 123456789, 123456789})
 		}
 	})
+
+	b.Run("IntSlice", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			cast.ToIntSlice([]string{"1", "2", "3", "4"})
+		}
+	})
+
+	b.Run("Duration", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			cast.ToDuration("10s")
+		}
+	})
 }
 
 // Alias types for alias testing


### PR DESCRIPTION
### Summary
- In `cast_test.go::BenchmarkCast`, add sub-benchmarks for `ToIntSlice` and `ToDuration` conversions.