### PR TITLE
Stringify non-string map keys in ToStringMapInt/Int64 reflect path

### DIFF
--- a/map.go
+++ b/map.go
@@ -179,7 +179,6 @@ func toStringMapIntE[T int | int64](i any, fn func(any) T, fnE func(any) (T, err
 		return m, fmt.Errorf(errorMsg, i, i, m)
 	}
 
-	mVal := reflect.ValueOf(m)
 	v := reflect.ValueOf(i)
 
 	for _, keyVal := range v.MapKeys() {
@@ -188,7 +187,7 @@ func toStringMapIntE[T int | int64](i any, fn func(any) T, fnE func(any) (T, err
 			return m, fmt.Errorf(errorMsg, i, i, m)
 		}
 
-		mVal.SetMapIndex(keyVal, reflect.ValueOf(val))
+		m[ToString(keyVal.Interface())] = val
 	}
 
 	return m, nil

--- a/map_test.go
+++ b/map_test.go
@@ -232,6 +232,7 @@ func TestStringMapInt(t *testing.T) {
 		{map[string]int32{"v1": int32(33), "v2": int32(88)}, map[string]int{"v1": 33, "v2": 88}, false},
 		{map[string]uint16{"v1": uint16(33), "v2": uint16(88)}, map[string]int{"v1": 33, "v2": 88}, false},
 		{map[string]float64{"v1": float64(8.22), "v2": float64(43.32)}, map[string]int{"v1": 8, "v2": 43}, false},
+		{map[int]int{1: 10, 2: 20}, map[string]int{"1": 10, "2": 20}, false},
 		{`{"v1": 67, "v2": 56}`, map[string]int{"v1": 67, "v2": 56}, false},
 
 		// Failure cases


### PR DESCRIPTION
`ToStringMapIntE` / `ToStringMapInt64E` **panic** on a map whose key type isn't `string` or `any` (e.g. `map[int]int`): the reflect fallback in `toStringMapIntE` does `mVal.SetMapIndex(keyVal, ...)` into a `map[string]T`, and reflect rejects the non-string key (`value of type int is not assignable to type string`).

This stringifies the key with `ToString` and assigns directly — matching the existing `map[any]...` cases — and adds a `map[int]int` regression case to `TestStringMapInt`.

Verified: the new case fails on current code and passes with the fix; the full `cast` suite stays green.

<sub>Developed with AI assistance (Claude Code); I directed, reviewed, and verified it locally.</sub>
